### PR TITLE
Add support for mupencheat.txt

### DIFF
--- a/.gitarchiveinclude
+++ b/.gitarchiveinclude
@@ -6,4 +6,5 @@ bin/evtest
 bin/gptokeyb2.LICENSE
 bin/minui-list-tg5040
 bin/sdl2imgshow
+mupen64plus/config/shared/mupencheat.txt
 res/fonts/BPreplayBold.otf

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ res/fonts/*
 
 !bin/gptokeyb2
 !bin/set_ra_cfg.sh
+mupen64plus/config/shared/mupencheat.txt

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,10 @@ clean:
 	rm -f bin/coreutils || true
 	rm -f bin/coreutils.LICENSE || true
 	rm -f bin/minui-list-* || true
+	rm -f mupen64plus/config/shared/mupencheat.txt || true
 	rm -f res/fonts/BPreplayBold.otf || true
 
-build: $(foreach platform,$(PLATFORMS),bin/minui-list-$(platform)) bin/7zzs bin/evtest bin/sdl2imgshow bin/coreutils bin/gptokeyb2.LICENSE res/fonts/BPreplayBold.otf
+build: $(foreach platform,$(PLATFORMS),bin/minui-list-$(platform)) bin/7zzs bin/evtest bin/sdl2imgshow bin/coreutils bin/gptokeyb2.LICENSE mupen64plus/config/shared/mupencheat.txt res/fonts/BPreplayBold.otf
 
 bin/7zzs:
 	curl -sSL -o bin/7z.tar.xz "https://www.7-zip.org/a/7z2409-linux-arm64.tar.xz"
@@ -52,6 +53,9 @@ bin/sdl2imgshow:
 	docker container cp extract:/go/src/github.com/kloptops/sdl2imgshow/build/sdl2imgshow bin/sdl2imgshow
 	docker container rm extract
 	chmod +x bin/sdl2imgshow
+
+mupen64plus/config/shared/mupencheat.txt:
+	curl -sSL -o mupen64plus/config/shared/mupencheat.txt "https://raw.githubusercontent.com/mupen64plus/mupen64plus-core/refs/heads/master/data/mupencheat.txt"
 
 res/fonts/BPreplayBold.otf:
 	mkdir -p res/fonts

--- a/launch.sh
+++ b/launch.sh
@@ -387,6 +387,13 @@ main() {
 
 	resolution="$(get_resolution)"
 
+	# date in timestamp format
+	date +%s
+	cheat_output=$(mupen64plus --cheats list --datadir "$XDG_DATA_HOME" --configdir "$XDG_CONFIG_HOME" --nosaveoptions --plugindir "$PLUGIN_DIR" --resolution "$resolution" --sshotdir "$SCREENSHOT_DIR" "$ROM_PATH" | grep -e "UI-Console" | grep -v -e "attached to core library" -e "Includes support for Dynamic Recompiler" -e "found for ROM" || true)
+	date +%s
+	cheat_output=$(echo "$cheat_output" | sed -e "s/^UI-Console:.\{4\}//")
+	date +%s
+
 	mkdir -p "$SDCARD_PATH/Screenshots"
 	if [ -f "$SAVESTATE_PATH" ]; then
 		mupen64plus --datadir "$XDG_DATA_HOME" --configdir "$XDG_CONFIG_HOME" --nosaveoptions --plugindir "$PLUGIN_DIR" --resolution "$resolution" --sshotdir "$SCREENSHOT_DIR" --savestate "$SAVESTATE_PATH" "$ROM_PATH" || true

--- a/launch.sh
+++ b/launch.sh
@@ -163,6 +163,9 @@ copy_libmupen64plus() {
 
 configure_platform() {
 	mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME"
+	if [ ! -f "$XDG_DATA_HOME/mupencheat.txt" ]; then
+		cp "$EMU_DIR/config/shared/mupencheat.txt" "$XDG_DATA_HOME/mupencheat.txt"
+	fi
 	if [ ! -f "$XDG_CONFIG_HOME/mupen64plus.cfg" ]; then
 		cp "$EMU_DIR/config/$PLATFORM/mupen64plus.cfg" "$XDG_CONFIG_HOME/mupen64plus.cfg"
 	fi


### PR DESCRIPTION
Todo:

- [ ] write golang parser that outputs `minui-list` compatible json
- [ ] update `minui-list` and use it to display cheats (all cheats should be disabled by default and under a separate header)
- [ ] add support for persisting enabled cheats and the selection options
- [ ] pass cheats along when executing `mupen64plus`

Closes #9