### PR TITLE
chore: hide the video plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,23 +105,6 @@ Allows changing the CPU Mode the emulator uses at runtime
 - default: `ondemand`
 - options: `ondemand`, `performance`
 
-#### Video Plugin
-
-> [!WARNING]
-> Setting the video plugin to `glide64` on `tg5040` devices currently results in an error, resulting in no video being shown on screen.
-
-Allows changing the `mupen64plus` video plugin.
-
-- default: `rice`
-- options: `rice`, `glide64`
-
-#### Aspect Ratio
-
-When `glide64` is selected as the video plugin, this allows changing the aspect ratio
-
-- default: `4:3`
-- options: `4:3`, `16:9`
-
 #### DPAD Mode
 
 Allows changing how the dpad is used in game

--- a/launch.sh
+++ b/launch.sh
@@ -130,17 +130,6 @@ settings_menu() {
 				echo "CPU Mode: Performance" >>"$minui_list_file"
 			fi
 
-			if [ "$video_plugin" = "rice" ]; then
-				echo "Video Plugin: Rice" >>"$minui_list_file"
-			else
-				echo "Video Plugin: Glide" >>"$minui_list_file"
-				if [ "$glide_aspect" = "4:3" ]; then
-					echo "Glide aspect ratio: 4:3" >>"$minui_list_file"
-				else
-					echo "Glide aspect ratio: 16:9" >>"$minui_list_file"
-				fi
-			fi
-
 			if [ "$dpad_mode" = "dpad" ]; then
 				echo "DPAD Mode: DPAD" >>"$minui_list_file"
 			elif [ "$dpad_mode" = "joystick" ]; then
@@ -218,16 +207,16 @@ get_rom_path() {
 
 	ROM_PATH=""
 	case "$*" in
-	*.n64 | *.v64 | *.z64)
-		ROM_PATH="$*"
-		;;
-	*.zip | *.7z)
-		echo performance >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-		echo 1800000 >/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
-		ROM_PATH="$TEMP_ROM"
+		*.n64 | *.v64 | *.z64)
+			ROM_PATH="$*"
+			;;
+		*.zip | *.7z)
+			echo performance >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+			echo 1800000 >/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+			ROM_PATH="$TEMP_ROM"
 
-		7zzs e "$*" -so >"$TEMP_ROM"
-		;;
+			7zzs e "$*" -so >"$TEMP_ROM"
+			;;
 	esac
 
 	echo "$ROM_PATH"


### PR DESCRIPTION
This setting results in a non-working system due to missing opengl support on the Brick, so just hide the setting. We can bring it back once this pak is tested working on another device/platform.

Closes #4