### PR TITLE
refactor: use options specified in config.json to drive minui-list

### DIFF
--- a/.gitarchiveinclude
+++ b/.gitarchiveinclude
@@ -3,6 +3,7 @@ bin/7zzs.LICENSE
 bin/coreutils
 bin/coreutils.LICENSE
 bin/evtest
+bin/jq
 bin/gptokeyb2.LICENSE
 bin/minui-list-tg5040
 bin/sdl2imgshow

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG ?= latest
 PAK_NAME := $(shell jq -r .label config.json)
 
 PLATFORMS := tg5040
-MINUI_LIST_VERSION := 0.5.0
+MINUI_LIST_VERSION := 0.6.0
 COREUTILS_VERSION := 0.0.28
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG ?= latest
 PAK_NAME := $(shell jq -r .label config.json)
 
 PLATFORMS := tg5040
-MINUI_LIST_VERSION := 0.4.0
+MINUI_LIST_VERSION := 0.5.0
 COREUTILS_VERSION := 0.0.28
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,14 @@ COREUTILS_VERSION := 0.0.28
 clean:
 	rm -f bin/7zzs* || true 
 	rm -f bin/evtest || true
+	rm -f bin/jq || true
 	rm -f bin/sdl2imgshow || true
 	rm -f bin/coreutils || true
 	rm -f bin/coreutils.LICENSE || true
 	rm -f bin/minui-list-* || true
 	rm -f res/fonts/BPreplayBold.otf || true
 
-build: $(foreach platform,$(PLATFORMS),bin/minui-list-$(platform)) bin/7zzs bin/evtest bin/sdl2imgshow bin/coreutils bin/gptokeyb2.LICENSE res/fonts/BPreplayBold.otf
+build: $(foreach platform,$(PLATFORMS),bin/minui-list-$(platform)) bin/7zzs bin/evtest bin/jq bin/sdl2imgshow bin/coreutils bin/gptokeyb2.LICENSE res/fonts/BPreplayBold.otf
 
 bin/7zzs:
 	curl -sSL -o bin/7z.tar.xz "https://www.7-zip.org/a/7z2409-linux-arm64.tar.xz"
@@ -41,6 +42,9 @@ bin/evtest:
 
 bin/gptokeyb2.LICENSE:
 	curl -sSL -o bin/gptokeyb2.LICENSE "https://raw.githubusercontent.com/PortsMaster/gptokeyb2/refs/heads/master/LICENSE.txt"
+
+bin/jq:
+	curl -f -o bin/jq -sSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64
 
 bin/minui-list-%:
 	curl -f -o bin/minui-list-$* -sSL https://github.com/josegonzalez/minui-list/releases/download/$(MINUI_LIST_VERSION)/minui-list-$*

--- a/config.json
+++ b/config.json
@@ -9,44 +9,44 @@
         {
             "name": "Controller Layout",
             "options": ["default", "lonko"],
-            "supports": {
+            "features": {
                 "confirm": false
             }
         },
         {
             "name": "DPAD Mode",
             "options": ["dpad", "joystick", "joystick-on-f2"],
-            "supports": {
+            "features": {
                 "confirm": false
             }
         },
         {
             "name": "CPU Mode",
             "options": ["ondemand", "performance"],
-            "supports": {
+            "features": {
                 "confirm": false
             }
         },
         {
             "name": "Video Plugin",
             "options": ["rice", "glide64mk2"],
-            "hidden": true,
-            "supports": {
-                "confirm": false
+            "features": {
+                "confirm": false,
+                "hidden": true
             }
         },
         {
             "name": "Glide Aspect Ratio",
             "options": ["4:3", "16:9"],
-            "hidden": true,
-            "supports": {
-                "confirm": false
+            "features": {
+                "confirm": false,
+                "hidden": true
             }
         },
         {
             "name": "Mupen64Plus Version",
             "options": ["2.5.9", "2.6.0"],
-            "supports": {
+            "features": {
                 "confirm": false
             }
         },

--- a/config.json
+++ b/config.json
@@ -1,5 +1,57 @@
 {
     "label": "N64",
     "launch": "launch.sh",
-    "description": "Runs mupen64plus in standalone mode for the specified rom"
+    "description": "Runs mupen64plus in standalone mode for the specified rom",
+    "platforms": [
+        "tg5040"
+    ],
+    "settings": [
+        {
+            "name": "Controller Layout",
+            "options": ["default", "lonko"],
+            "supports": {
+                "confirm": false
+            }
+        },
+        {
+            "name": "DPAD Mode",
+            "options": ["dpad", "joystick", "joystick-on-f2"],
+            "supports": {
+                "confirm": false
+            }
+        },
+        {
+            "name": "CPU Mode",
+            "options": ["ondemand", "performance"],
+            "supports": {
+                "confirm": false
+            }
+        },
+        {
+            "name": "Video Plugin",
+            "options": ["rice", "glide64mk2"],
+            "hidden": true,
+            "supports": {
+                "confirm": false
+            }
+        },
+        {
+            "name": "Glide Aspect Ratio",
+            "options": ["4:3", "16:9"],
+            "hidden": true,
+            "supports": {
+                "confirm": false
+            }
+        },
+        {
+            "name": "Mupen64Plus Version",
+            "options": ["2.5.9", "2.6.0"],
+            "supports": {
+                "confirm": false
+            }
+        },
+        {
+            "name": "Save settings for game"
+        }
+    ]
 }

--- a/config.json
+++ b/config.json
@@ -10,44 +10,28 @@
             "name": "Controller Layout",
             "options": ["default", "lonko"],
             "features": {
-                "confirm": false
+                "hide_confirm": false
             }
         },
         {
             "name": "DPAD Mode",
             "options": ["dpad", "joystick", "joystick-on-f2"],
             "features": {
-                "confirm": false
+                "hide_confirm": false
             }
         },
         {
             "name": "CPU Mode",
             "options": ["ondemand", "performance"],
             "features": {
-                "confirm": false
-            }
-        },
-        {
-            "name": "Video Plugin",
-            "options": ["rice", "glide64mk2"],
-            "features": {
-                "confirm": false,
-                "hidden": true
-            }
-        },
-        {
-            "name": "Glide Aspect Ratio",
-            "options": ["4:3", "16:9"],
-            "features": {
-                "confirm": false,
-                "hidden": true
+                "hide_confirm": false
             }
         },
         {
             "name": "Mupen64Plus Version",
             "options": ["2.5.9", "2.6.0"],
             "features": {
-                "confirm": false
+                "hide_confirm": false
             }
         },
         {

--- a/launch.sh
+++ b/launch.sh
@@ -145,14 +145,27 @@ settings_menu() {
 			fi
 
 			echo "Save settings for game" >>"$minui_list_file"
-			echo "Start game" >>"$minui_list_file"
 
-			selection="$("minui-list-$PLATFORM" --format text --file "$minui_list_file" --header "N64 Settings")"
-			exit_code=$?
-			# exit codes: 2 = back button, 3 = menu button
-			if [ "$exit_code" -ne 0 ]; then
-				break
-			fi
+			selection="$("minui-list-$PLATFORM" --format text --file "$minui_list_file" --header "N64 Settings" --action-button "X" --action-text "PLAY")" || {
+				exit_code="$?"
+				# 4 = action button
+				# we break out of the loop because the action button is the play button
+				if [ "$exit_code" -eq 4 ]; then
+					echo "$controller_layout" >"$GAMESETTINGS_DIR/controller-layout.tmp"
+					echo "$cpu_mode" >"$GAMESETTINGS_DIR/cpu-mode.tmp"
+					echo "$dpad_mode" >"$GAMESETTINGS_DIR/dpad-mode.tmp"
+					echo "$glide_aspect" >"$GAMESETTINGS_DIR/glide-aspect.tmp"
+					echo "$mupen64plus_version" >"$GAMESETTINGS_DIR/mupen64plus-version.tmp"
+					echo "$video_plugin" >"$GAMESETTINGS_DIR/video-plugin.tmp"
+					break
+				fi
+
+				# 2 = back button, 3 = menu button
+				# both are errors, so we exit with the exit code
+				if [ "$exit_code" -ne 0 ]; then
+					exit "$exit_code"
+				fi
+			}
 
 			if echo "$selection" | grep -q "^Controller Layout: Default$"; then
 				controller_layout="lonko"

--- a/launch.sh
+++ b/launch.sh
@@ -100,8 +100,11 @@ get_video_plugin() {
 settings_menu() {
 	mkdir -p "$GAMESETTINGS_DIR"
 
+	rm -f "$GAMESETTINGS_DIR/controller-layout.tmp"
+	rm -f "$GAMESETTINGS_DIR/cpu-mode.tmp"
 	rm -f "$GAMESETTINGS_DIR/dpad-mode.tmp"
 	rm -f "$GAMESETTINGS_DIR/glide-aspect.tmp"
+	rm -f "$GAMESETTINGS_DIR/mupen64plus-version.tmp"
 	rm -f "$GAMESETTINGS_DIR/video-plugin.tmp"
 
 	controller_layout="$(get_controller_layout)"


### PR DESCRIPTION
This allows for faster, more intuitive emulator settings interactions as folks can just scroll back and forth across options without needing to stop/start minui-list to persist settings. The new action button is used to immediately play with the configured settings, while the confirm button is used solely to save the settings for the game.

One nice thing about this is that adding new options is quite a bit simpler, and its easier for users to see what options are available by checking the config.json for the pak.