### PR TITLE
feat: add analog stick sensitivity modifier shortcuts

### DIFF
--- a/config/shared/launch.sh
+++ b/config/shared/launch.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 PAK_DIR="$(dirname "$0")"
-PAK_NAME="$(basename "$PAK_DIR")"
-PAK_NAME="${PAK_NAME%.*}"
+EMU_TAG="$(basename "$PAK_DIR")"
+EMU_TAG="${EMU_TAG%.*}"
 set -x
 
-rm -f "$LOGS_PATH/$PAK_NAME.txt"
-exec >>"$LOGS_PATH/$PAK_NAME.txt"
+rm -f "$LOGS_PATH/$EMU_TAG.txt"
+exec >>"$LOGS_PATH/$EMU_TAG.txt"
 exec 2>&1
 
-EMU_TAG=$(basename "$(dirname "$0")" .pak)
 BIN_DIR="$PAK_DIR/$PLATFORM"
 ROM="$1"
+ROM_BASE="$(basename "$ROM")"
 
 mkdir -p "$SAVES_PATH/$EMU_TAG"
 
@@ -70,27 +70,6 @@ echo 3 >/proc/sys/vm/drop_caches 2>/dev/null
 # the Brick and Smart Pro variants, so those two need a suffix within the
 # tg5040 platform dir. tg5050 has no variants.
 USERDATA_DIR="$USERDATA_PATH/$EMU_TAG-mupen64plus"
-case "$PLATFORM" in
-    tg5040)
-        if [ "$DEVICE" = "brick" ]; then
-            DEVICE_CONFIG_DIR="$USERDATA_DIR/brick"
-            DEVICE_RESOLUTION="1024x768"
-            DEVICE_ANISOTROPY=0
-        else
-            DEVICE_CONFIG_DIR="$USERDATA_DIR/smart-pro"
-            DEVICE_RESOLUTION="1280x720"
-            DEVICE_ANISOTROPY=0
-        fi
-        ;;
-    tg5050)
-        DEVICE_CONFIG_DIR="$USERDATA_DIR"
-        DEVICE_RESOLUTION="1280x720"
-        # Anisotropic filtering: sharpens textures viewed at oblique angles.
-        # Mali-G57 (tg5050) can handle level 2; PowerVR GE8300 (tg5040) cannot.
-        DEVICE_ANISOTROPY=2
-        ;;
-esac
-
 # Migrate from the legacy shared-userdata path if present. This moves the
 # user's mupen64plus.cfg, .initialized marker, per-game/ overrides, and
 # anything else into the new per-platform location. Kept for one release;
@@ -99,12 +78,22 @@ LEGACY_USERDATA_DIR="$SHARED_USERDATA_PATH/N64-mupen64plus"
 case "$PLATFORM" in
     tg5040)
         if [ "$DEVICE" = "brick" ]; then
+            DEVICE_CONFIG_DIR="$USERDATA_DIR/brick"
+            DEVICE_RESOLUTION="1024x768"
             LEGACY_CONFIG_DIR="$LEGACY_USERDATA_DIR/config/tg5040-brick"
         else
+            DEVICE_CONFIG_DIR="$USERDATA_DIR/smart-pro"
+            DEVICE_RESOLUTION="1280x720"
             LEGACY_CONFIG_DIR="$LEGACY_USERDATA_DIR/config/tg5040-smart-pro"
         fi
+        DEVICE_ANISOTROPY=0
         ;;
     tg5050)
+        DEVICE_CONFIG_DIR="$USERDATA_DIR"
+        DEVICE_RESOLUTION="1280x720"
+        # Anisotropic filtering: sharpens textures viewed at oblique angles.
+        # Mali-G57 (tg5050) can handle level 2; PowerVR GE8300 (tg5040) cannot.
+        DEVICE_ANISOTROPY=2
         LEGACY_CONFIG_DIR="$LEGACY_USERDATA_DIR/config/tg5050"
         ;;
 esac
@@ -205,8 +194,7 @@ export EMU_ROM_PATH="${ROM#/mnt/SDCARD}"
 # ── Overlay menu config ──────────────────────────────────────────────────────
 export EMU_OVERLAY_JSON="$BIN_DIR/overlay_settings.json"
 export EMU_OVERLAY_INI="$DEVICE_CONFIG_DIR/mupen64plus.cfg"
-_ROM_BASE="$(basename "$ROM")"
-export EMU_OVERLAY_GAME="${_ROM_BASE%.*}"
+export EMU_OVERLAY_GAME="${ROM_BASE%.*}"
 export EMU_DEFAULT_CFG="$BIN_DIR/default.cfg"
 
 # ── Video plugin selection (reads [NextUI] VideoPlugin from mupen64plus.cfg) ─
@@ -232,13 +220,17 @@ RES_DIR="$SDCARD_PATH/.system/res"
 MINUI_SETTINGS="$SDCARD_PATH/.userdata/shared/minuisettings.txt"
 FONT_ID=$(awk -F= '$1=="font"{print $2; exit}' "$MINUI_SETTINGS" 2>/dev/null)
 case "$FONT_ID" in
-    1) FONT_FILE="$RES_DIR/font1.ttf" ;;
-    *) FONT_FILE="$RES_DIR/font2.ttf" ;;
+    1) FONT_CANDIDATES="font1.ttf font2.ttf" ;;
+    *) FONT_CANDIDATES="font2.ttf font1.ttf" ;;
 esac
-[ -f "$FONT_FILE" ] || FONT_FILE="$RES_DIR/font2.ttf"
-[ -f "$FONT_FILE" ] || FONT_FILE="$RES_DIR/font1.ttf"
-[ -f "$FONT_FILE" ] || FONT_FILE="$RES_DIR/BPreplayBold-unhinted.otf"
-if [ ! -f "$FONT_FILE" ]; then
+FONT_FILE=""
+for name in $FONT_CANDIDATES BPreplayBold-unhinted.otf; do
+    if [ -f "$RES_DIR/$name" ]; then
+        FONT_FILE="$RES_DIR/$name"
+        break
+    fi
+done
+if [ -z "$FONT_FILE" ]; then
     # Last resort: pick the first .ttf or .otf in the res directory
     for f in "$RES_DIR"/*.ttf "$RES_DIR"/*.otf; do
         if [ -f "$f" ]; then
@@ -252,12 +244,12 @@ export EMU_OVERLAY_FONT="$FONT_FILE"
 MINUI_DIR="$SHARED_USERDATA_PATH/.minui/$EMU_TAG"
 mkdir -p "$MINUI_DIR"
 export EMU_OVERLAY_SCREENSHOT_DIR="$MINUI_DIR"
-export EMU_OVERLAY_ROMFILE="$(basename "$ROM")"
+export EMU_OVERLAY_ROMFILE="$ROM_BASE"
 
 # ── Per-game settings ────────────────────────────────────────────────────────
 PER_GAME_DIR="$DEVICE_CONFIG_DIR/per-game"
 mkdir -p "$PER_GAME_DIR"
-PER_GAME_CFG="$PER_GAME_DIR/$(basename "$ROM").cfg"
+PER_GAME_CFG="$PER_GAME_DIR/$ROM_BASE.cfg"
 export EMU_PER_GAME_CFG="$PER_GAME_CFG"
 
 # If a per-game config exists, overlay its values onto mupen64plus.cfg for
@@ -327,7 +319,7 @@ fi
 # time and toggles on user action. Flag files are cleaned up on exit.
 
 # Runtime button remap file for immediate application in input-sdl
-export EMU_BUTTON_MAP_FILE="$PER_GAME_DIR/$(basename "$ROM").buttons"
+export EMU_BUTTON_MAP_FILE="$PER_GAME_DIR/$ROM_BASE.buttons"
 
 # ── Archive extraction ───────────────────────────────────────────────────────
 # If the ROM is a .zip or .7z, extract the inner N64 ROM to a tmpfs directory
@@ -375,8 +367,7 @@ case "$ROM" in
         fi
         # Rename so the basename matches the archive (sans .zip/.7z). This is
         # what mupen64plus-ui-console.patch reads for M64CMD_SET_ROM_FILENAME.
-        ROM_BASENAME=$(basename "$ROM_ARCHIVE")
-        ROM_STEM="${ROM_BASENAME%.*}"
+        ROM_STEM="${ROM_BASE%.*}"
         ROM_RENAMED="$ROM_EXTRACT_DIR/${ROM_STEM}.z64"
         if [ "$ROM_INNER" != "$ROM_RENAMED" ]; then
             mv "$ROM_INNER" "$ROM_RENAMED"

--- a/config/shared/launch.sh
+++ b/config/shared/launch.sh
@@ -205,7 +205,8 @@ export EMU_ROM_PATH="${ROM#/mnt/SDCARD}"
 # ── Overlay menu config ──────────────────────────────────────────────────────
 export EMU_OVERLAY_JSON="$BIN_DIR/overlay_settings.json"
 export EMU_OVERLAY_INI="$DEVICE_CONFIG_DIR/mupen64plus.cfg"
-export EMU_OVERLAY_GAME="$(basename "$ROM" | sed 's/\.[^.]*$//')"
+_ROM_BASE="$(basename "$ROM")"
+export EMU_OVERLAY_GAME="${_ROM_BASE%.*}"
 export EMU_DEFAULT_CFG="$BIN_DIR/default.cfg"
 
 # ── Video plugin selection (reads [NextUI] VideoPlugin from mupen64plus.cfg) ─

--- a/overlay/emu_frontend.c
+++ b/overlay/emu_frontend.c
@@ -13,6 +13,9 @@
 // Frame skip: owned here, read by GLideN64 RSP.cpp via extern
 int g_frameSkip = 0;
 
+// Analog sensitivity: owned by ui-console main.c, written here, read by input-sdl
+extern int g_analogSensitivity;
+
 // Forward declarations for scope-aware save system
 static const char* get_per_game_path(void);
 static EmuConfigScope compute_scope(void);
@@ -707,29 +710,35 @@ static bool btn_is_held(int b) {
 }
 
 // ---------------------------------------------------------------------------
-// Shortcut bindings (19 remappable shortcuts — same model as controls)
+// Shortcut bindings (25 remappable shortcuts — same model as controls)
 // ---------------------------------------------------------------------------
 
 static ShortcutBinding s_shortcuts[SHORTCUT_COUNT] = {
-	{"shortcut_cycle_aspect",      "Cycle Aspect Ratio",   -1, 0, 0, 0},
-	{"shortcut_game_switcher",     "Game Switcher",        -1, 0, 0, 0},
-	{"shortcut_hold_ff",           "Hold Fast Forward",    -1, 0, 0, 0},
-	{"shortcut_hold_rewind",       "Hold Rewind",          -1, 0, 0, 0},
-	{"shortcut_load_state",        "Quick Load",           -1, 0, 0, 0},
-	{"shortcut_reset",             "Reset Game",           -1, 0, 0, 0},
-	{"shortcut_save_state",        "Quick Save",           -1, 0, 0, 0},
-	{"shortcut_screenshot",        "Screenshot",           -1, 0, 0, 0},
-	{"shortcut_toggle_ff",         "Toggle Fast Forward",  -1, 0, 0, 0},
-	{"shortcut_toggle_input_mode", "Toggle Input Mode",    -1, 0, 0, 0},
-	{"shortcut_toggle_rewind",     "Toggle Rewind",        -1, 0, 0, 0},
-	{"shortcut_turbo_a",           "Toggle Turbo A",       -1, 0, 0, 0},
-	{"shortcut_turbo_b",           "Toggle Turbo B",       -1, 0, 0, 0},
-	{"shortcut_turbo_l",           "Toggle Turbo L",       -1, 0, 0, 0},
-	{"shortcut_turbo_l2",          "Toggle Turbo L2",      -1, 0, 0, 0},
-	{"shortcut_turbo_r",           "Toggle Turbo R",       -1, 0, 0, 0},
-	{"shortcut_turbo_r2",          "Toggle Turbo R2",      -1, 0, 0, 0},
-	{"shortcut_turbo_x",           "Toggle Turbo X",       -1, 0, 0, 0},
-	{"shortcut_turbo_y",           "Toggle Turbo Y",       -1, 0, 0, 0},
+	{"shortcut_cycle_aspect",           "Cycle Aspect Ratio",      -1, 0, 0, 0},
+	{"shortcut_game_switcher",          "Game Switcher",           -1, 0, 0, 0},
+	{"shortcut_hold_ff",                "Hold Fast Forward",       -1, 0, 0, 0},
+	{"shortcut_hold_rewind",            "Hold Rewind",             -1, 0, 0, 0},
+	{"shortcut_hold_sensitivity_25",    "Hold Sensitivity 25%",    -1, 0, 0, 0},
+	{"shortcut_hold_sensitivity_50",    "Hold Sensitivity 50%",    -1, 0, 0, 0},
+	{"shortcut_hold_sensitivity_75",    "Hold Sensitivity 75%",    -1, 0, 0, 0},
+	{"shortcut_load_state",             "Quick Load",              -1, 0, 0, 0},
+	{"shortcut_reset",                  "Reset Game",              -1, 0, 0, 0},
+	{"shortcut_save_state",             "Quick Save",              -1, 0, 0, 0},
+	{"shortcut_screenshot",             "Screenshot",              -1, 0, 0, 0},
+	{"shortcut_toggle_ff",              "Toggle Fast Forward",     -1, 0, 0, 0},
+	{"shortcut_toggle_input_mode",      "Toggle Input Mode",       -1, 0, 0, 0},
+	{"shortcut_toggle_rewind",          "Toggle Rewind",           -1, 0, 0, 0},
+	{"shortcut_toggle_sensitivity_25",  "Toggle Sensitivity 25%",  -1, 0, 0, 0},
+	{"shortcut_toggle_sensitivity_50",  "Toggle Sensitivity 50%",  -1, 0, 0, 0},
+	{"shortcut_toggle_sensitivity_75",  "Toggle Sensitivity 75%",  -1, 0, 0, 0},
+	{"shortcut_turbo_a",                "Toggle Turbo A",          -1, 0, 0, 0},
+	{"shortcut_turbo_b",                "Toggle Turbo B",          -1, 0, 0, 0},
+	{"shortcut_turbo_l",                "Toggle Turbo L",          -1, 0, 0, 0},
+	{"shortcut_turbo_l2",               "Toggle Turbo L2",         -1, 0, 0, 0},
+	{"shortcut_turbo_r",                "Toggle Turbo R",          -1, 0, 0, 0},
+	{"shortcut_turbo_r2",               "Toggle Turbo R2",         -1, 0, 0, 0},
+	{"shortcut_turbo_x",                "Toggle Turbo X",          -1, 0, 0, 0},
+	{"shortcut_turbo_y",                "Toggle Turbo Y",          -1, 0, 0, 0},
 };
 
 ShortcutBinding* emu_frontend_get_shortcuts(void) {
@@ -1001,6 +1010,52 @@ static void process_fast_forward(void) {
 			set_fast_forward(s_ffToggledOn);
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Analog sensitivity modifier (toggle + hold shortcuts)
+// ---------------------------------------------------------------------------
+
+static int s_sensitivityToggleLevel = 0;  // 0=off, 25, 50, 75
+static int s_sensitivityHoldLevel = 0;
+static bool s_sensitivityHoldActive = false;
+
+static void process_sensitivity_shortcuts(void) {
+	static const int levels[] = {25, 50, 75};
+	static const char* toggle_keys[] = {
+		"shortcut_toggle_sensitivity_25",
+		"shortcut_toggle_sensitivity_50",
+		"shortcut_toggle_sensitivity_75",
+	};
+	static const char* hold_keys[] = {
+		"shortcut_hold_sensitivity_25",
+		"shortcut_hold_sensitivity_50",
+		"shortcut_hold_sensitivity_75",
+	};
+
+	// Toggles: same level = off, different level = switch
+	for (int i = 0; i < 3; i++) {
+		if (emu_frontend_shortcut_just_pressed(find_shortcut(toggle_keys[i])))
+			s_sensitivityToggleLevel = (s_sensitivityToggleLevel == levels[i]) ? 0 : levels[i];
+	}
+
+	// Holds: first-match wins, override toggle while active
+	int hold_level = 0;
+	bool any_held = false;
+	for (int i = 0; i < 3; i++) {
+		ShortcutBinding* s = find_shortcut(hold_keys[i]);
+		if (s && s->physical >= 0 && emu_frontend_shortcut_is_held(s)) {
+			hold_level = levels[i];
+			any_held = true;
+			break;
+		}
+	}
+	s_sensitivityHoldActive = any_held;
+	if (any_held) s_sensitivityHoldLevel = hold_level;
+
+	// Update shared global (read by input-sdl plugin)
+	g_analogSensitivity = s_sensitivityHoldActive
+		? s_sensitivityHoldLevel : s_sensitivityToggleLevel;
 }
 
 // ---------------------------------------------------------------------------
@@ -2242,6 +2297,7 @@ void emu_frontend_frame(int w, int h) {
 		process_rewind();
 		process_turbo_and_aspect_shortcuts();
 		process_input_mode_shortcut();
+		process_sensitivity_shortcuts();
 	}
 
 	// Overlay menu: ensure loaded, then handle menu button press
@@ -2255,6 +2311,7 @@ void emu_frontend_frame(int w, int h) {
 void emu_frontend_cleanup(void) {
 	rewind_cleanup();
 	clear_turbo_files();
+	g_analogSensitivity = 0;
 	// Clean up trimui_inputd flag files so we don't leak d-pad remap state
 	// to other emulators. launch.sh's exit trap also does this as a safety net.
 	unlink("/tmp/trimui_inputd/input_dpad_to_joystick");

--- a/overlay/emu_frontend.h
+++ b/overlay/emu_frontend.h
@@ -58,8 +58,8 @@ EmuOvlConfig* emu_frontend_get_overlay_config(void);
 // Button state tracking (called every frame)
 void emu_frontend_update_buttons(void);
 
-// Shortcut binding (19 remappable shortcuts — same capture/modifier model as controls)
-#define SHORTCUT_COUNT 19
+// Shortcut binding (25 remappable shortcuts — same capture/modifier model as controls)
+#define SHORTCUT_COUNT 25
 typedef struct {
 	const char* key;       // config key: "shortcut_toggle_ff", etc.
 	const char* label;     // display name: "Toggle Fast Forward", etc.
@@ -83,6 +83,10 @@ bool emu_frontend_shortcut_is_held(const ShortcutBinding* s);
 
 // Frame skip value (owned by emu_frontend, read by GLideN64 RSP.cpp via extern)
 extern int g_frameSkip;
+
+// Analog sensitivity modifier (owned by ui-console main.c, written by emu_frontend)
+// 0 = 100% (default), 25/50/75 = output percentage
+extern int g_analogSensitivity;
 
 // N64 button mapping (10 remappable action buttons)
 #define N64_REMAP_COUNT 10

--- a/patches/shared/mupen64plus-core.patch
+++ b/patches/shared/mupen64plus-core.patch
@@ -1,3 +1,27 @@
+diff --git a/src/api/api_export.ver b/src/api/api_export.ver
+index 289adf2..6dbe3e8 100644
+--- a/src/api/api_export.ver
++++ b/src/api/api_export.ver
+@@ -1,4 +1,5 @@
+ { global:
++g_analogSensitivity;
+ ConfigExternalGetParameter;
+ ConfigExternalOpen;
+ ConfigExternalClose;
+diff --git a/src/api/callbacks.c b/src/api/callbacks.c
+index 0a3c49b..183eead 100644
+--- a/src/api/callbacks.c
++++ b/src/api/callbacks.c
+@@ -31,6 +31,9 @@
+ #include "callbacks.h"
+ #include "m64p_types.h"
+ 
++/* Shared plugin variables (exported via api_export.ver) */
++__attribute__((visibility("default"))) int g_analogSensitivity = 0; /* 0=100%, 25/50/75=output % */
++
+ /* local variables */
+ static ptr_DebugCallback pDebugFunc = NULL;
+ static ptr_StateCallback pStateFunc = NULL;
 diff --git a/src/api/frontend.c b/src/api/frontend.c
 index 956f96f..b3d3235 100644
 --- a/src/api/frontend.c

--- a/patches/shared/mupen64plus-input-sdl.patch
+++ b/patches/shared/mupen64plus-input-sdl.patch
@@ -1,5 +1,5 @@
 diff --git a/src/plugin.c b/src/plugin.c
-index 974b1db..76efb35 100644
+index 974b1db..edaa2c3 100644
 --- a/src/plugin.c
 +++ b/src/plugin.c
 @@ -27,6 +27,7 @@
@@ -10,7 +10,29 @@ index 974b1db..76efb35 100644
  
  #define M64P_PLUGIN_PROTOTYPES 1
  #include "config.h"
-@@ -614,6 +615,149 @@ EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
+@@ -57,6 +58,10 @@
+ #define test_bit(bit, array)    ((array[LONG(bit)] >> OFF(bit)) & 1)
+ #endif //__linux__
+ 
++/* Analog sensitivity modifier (0=100%, 25/50/75=output %).
++ * Defined in mupen64plus (ui-console main.c); written by overlay. */
++extern int g_analogSensitivity;
++
+ /* definitions of pointers to Core config functions */
+ ptr_ConfigOpenSection      ConfigOpenSection = NULL;
+ ptr_ConfigDeleteSection    ConfigDeleteSection = NULL;
+@@ -510,6 +515,10 @@ EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
+     if (myKeyState[SDL_SCANCODE_RSHIFT])
+         axis_max_val -= 25;
+ 
++    // Analog sensitivity modifier from overlay shortcut
++    if (g_analogSensitivity > 0)
++        axis_max_val = axis_max_val * g_analogSensitivity / 100;
++
+     for ( b = 0; b < 4; ++b )
+     {
+         if (controller[b].device >= 0)
+@@ -614,6 +623,149 @@ EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
          controller[Control].buttons.Y_AXIS = iY;
      }
  


### PR DESCRIPTION
## Summary

- Add 6 remappable shortcuts for analog stick sensitivity: toggle and hold variants at 25%, 50%, and 75% output levels
- Simplify launch.sh by unifying duplicate variables (`PAK_NAME`/`EMU_TAG`), caching `basename` calls, merging parallel `case` blocks, and cleaning up font fallback logic

The sensitivity modifier uses a shared global variable (`g_analogSensitivity`) in the core library to communicate between the overlay (writer) and input plugin (reader), following the existing `g_frameSkip` cross-plugin pattern.