### PR TITLE
feat: add ini CLI tool, standard INI per-game configs, scoped LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,17 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    name: test
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run ini tool tests
+        run: make -C tools/ini test
+
   build:
     name: build
     runs-on: ubuntu-24.04-arm

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ src/
 
 # Build output
 dist/
+tools/ini/build/
+tools/ini/dist/
 
 # Populated from nx-redux at build time
 include/

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ DOCKER_SCRIPT := /build/src/.docker-env.sh
 # Top-level targets
 # ══════════════════════════════════════════════════════════════════════════════
 
-.PHONY: all build tg5040 tg5050 gliden64 rice dist clone patch patches clean
+.PHONY: all build tg5040 tg5050 gliden64 rice dist clone patch patches clean \
+       ini-tg5040 ini-tg5050
 
 build: clone patch
 	$(MAKE) tg5040
@@ -78,6 +79,8 @@ build: clone patch
 	$(MAKE) gliden64
 	$(MAKE) rice-tg5040
 	$(MAKE) rice-tg5050
+	$(MAKE) ini-tg5040
+	$(MAKE) ini-tg5050
 
 # Build both platforms sequentially, staging outputs between builds since they
 # share source directories.
@@ -258,6 +261,18 @@ rice-tg5040: $(PATCH_STAMP)
 rice-tg5050: $(PATCH_STAMP) tg5050-libpng-headers
 	$(DOCKER_RUN_5050) bash -c 'cd /build/src/mupen64plus-video-rice/projects/unix && rm -rf _obj mupen64plus-video-rice.so && make -j$$(nproc) all $(PLUGIN_MAKE) USE_GLES=1 CPPFLAGS="-I/build/include" LIBPNG_CFLAGS="-I/build/src/libpng-headers/libpng-1.6.37" LIBPNG_LDLIBS="-lpng16 -lz"'
 
+# ── INI CLI tool (pure C, no SDK dependencies) ──────────────────────────────
+
+ini-tg5040:
+	$(DOCKER_RUN_5040) bash -c 'cd /build/tools/ini && make clean all CROSS_COMPILE=$(CROSS)'
+	mkdir -p $(ROOT)/tools/ini/dist/tg5040
+	cp $(ROOT)/tools/ini/build/ini $(ROOT)/tools/ini/dist/tg5040/ini
+
+ini-tg5050:
+	$(DOCKER_RUN_5050) bash -c 'cd /build/tools/ini && make clean all CROSS_COMPILE=$(CROSS)'
+	mkdir -p $(ROOT)/tools/ini/dist/tg5050
+	cp $(ROOT)/tools/ini/build/ini $(ROOT)/tools/ini/dist/tg5050/ini
+
 # ── Dist assembly ─────────────────────────────────────────────────────────────
 
 .PHONY: dist dist-tg5040 dist-tg5050
@@ -290,6 +305,7 @@ dist-tg5040:
 	cp $(SRC)/mupen64plus-rsp-hle/projects/unix/mupen64plus-rsp-hle.so     $(DIST)/tg5040/
 	cp $(SRC)/mupen64plus-video-rice/projects/unix/mupen64plus-video-rice.so $(DIST)/tg5040/
 	$(call DIST_COMMON,$(DIST)/tg5040)
+	cp $(ROOT)/tools/ini/dist/tg5040/ini $(DIST)/tg5040/
 	$(DOCKER_RUN_5050) install -m 0644 /opt/aarch64-nextui-linux-gnu/aarch64-nextui-linux-gnu/libc/usr/lib/libpng16.so.16.37.0 /build/dist/N64.pak/tg5040/libpng16.so.16
 	$(DOCKER_RUN_5050) install -m 0644 /opt/aarch64-nextui-linux-gnu/aarch64-nextui-linux-gnu/libc/usr/lib/libz.so.1.2.12 /build/dist/N64.pak/tg5040/libz.so.1
 
@@ -303,6 +319,7 @@ dist-tg5050:
 	cp $(SRC)/mupen64plus-rsp-hle/projects/unix/mupen64plus-rsp-hle.so     $(DIST)/tg5050/
 	cp $(SRC)/mupen64plus-video-rice/projects/unix/mupen64plus-video-rice.so $(DIST)/tg5050/
 	$(call DIST_COMMON,$(DIST)/tg5050)
+	cp $(ROOT)/tools/ini/dist/tg5050/ini $(DIST)/tg5050/
 	$(DOCKER_RUN_5050) install -m 0644 /opt/aarch64-nextui-linux-gnu/aarch64-nextui-linux-gnu/libc/usr/lib/libpng16.so.16.37.0 /build/dist/N64.pak/tg5050/libpng16.so.16
 	$(DOCKER_RUN_5050) install -m 0644 /opt/aarch64-nextui-linux-gnu/aarch64-nextui-linux-gnu/libc/usr/lib/libz.so.1.2.12 /build/dist/N64.pak/tg5050/libz.so.1
 
@@ -337,3 +354,5 @@ patches:
 clean:
 	rm -rf $(SRC) $(ROOT)/dist $(ROOT)/include
 	rm -f $(PATCHES)/mupen64plus-audio-sdl.patch
+	cd $(ROOT)/tools/ini && make clean
+	rm -rf $(ROOT)/tools/ini/dist

--- a/config/shared/launch.sh
+++ b/config/shared/launch.sh
@@ -126,11 +126,7 @@ SCREEN_H="${DEVICE_RESOLUTION#*x}"
 
 # Read the user's console-level anisotropy from the config file so we can
 # detect whether they customised it away from the device default.
-CONSOLE_ANISOTROPY=$(awk -F' = ' '
-    /^\[Video-GLideN64\]/ { in_section=1; next }
-    /^\[/                 { in_section=0 }
-    in_section && $1 == "anisotropy" { print $2; exit }
-' "$DEVICE_CFG" 2>/dev/null)
+CONSOLE_ANISOTROPY=$("$BIN_DIR/ini" get "$DEVICE_CFG" "Video-GLideN64" "anisotropy" 2>/dev/null)
 
 # Align save paths with NextUI conventions
 BATTERY_SAVE_DIR="$SAVES_PATH/$EMU_TAG"
@@ -184,8 +180,10 @@ fi
 # ── Environment ───────────────────────────────────────────────────────────────
 export HOME="$USERDATA_PATH"
 export XDG_DATA_HOME="$DEVICE_CONFIG_DIR"
-export LD_LIBRARY_PATH="$BIN_DIR:$SDCARD_PATH/.system/$PLATFORM/lib:/usr/trimui/lib:$LD_LIBRARY_PATH"
-export LD_PRELOAD="libEGL.so"
+# LD_LIBRARY_PATH and LD_PRELOAD are scoped to the mupen64plus invocation
+# below to avoid affecting sleepmon.elf, syncsettings.elf, and taskset.
+M64P_LD_LIBRARY_PATH="$BIN_DIR:$SDCARD_PATH/.system/$PLATFORM/lib:/usr/trimui/lib:$LD_LIBRARY_PATH"
+M64P_LD_PRELOAD="libEGL.so"
 # Relative ROM path for auto_resume.txt (strip /mnt/SDCARD prefix)
 export EMU_ROM_PATH="${ROM#/mnt/SDCARD}"
 # Pass resume slot to emulator if game switcher requested it
@@ -198,11 +196,7 @@ export EMU_OVERLAY_GAME="${ROM_BASE%.*}"
 export EMU_DEFAULT_CFG="$BIN_DIR/default.cfg"
 
 # ── Video plugin selection (reads [NextUI] VideoPlugin from mupen64plus.cfg) ─
-VIDEO_PLUGIN_VALUE=$(awk -F' = ' '
-    /^\[NextUI\]/ { in_section=1; next }
-    /^\[/         { in_section=0 }
-    in_section && $1 == "VideoPlugin" { gsub(/[[:space:]]+/, "", $2); print $2; exit }
-' "$DEVICE_CFG" 2>/dev/null)
+VIDEO_PLUGIN_VALUE=$("$BIN_DIR/ini" get "$DEVICE_CFG" "NextUI" "VideoPlugin" 2>/dev/null)
 case "$VIDEO_PLUGIN_VALUE" in
     0)
         GFX_PLUGIN="mupen64plus-video-GLideN64.so"
@@ -218,7 +212,7 @@ esac
 # the res directory. This keeps the overlay functional on both NextUI and MinUI.
 RES_DIR="$SDCARD_PATH/.system/res"
 MINUI_SETTINGS="$SDCARD_PATH/.userdata/shared/minuisettings.txt"
-FONT_ID=$(awk -F= '$1=="font"{print $2; exit}' "$MINUI_SETTINGS" 2>/dev/null)
+FONT_ID=$("$BIN_DIR/ini" get "$MINUI_SETTINGS" "" "font" 2>/dev/null)
 case "$FONT_ID" in
     1) FONT_CANDIDATES="font1.ttf font2.ttf" ;;
     *) FONT_CANDIDATES="font2.ttf font1.ttf" ;;
@@ -258,50 +252,13 @@ export EMU_PER_GAME_CFG="$PER_GAME_CFG"
 if [ -f "$PER_GAME_CFG" ]; then
     cp "$DEVICE_CFG" "$DEVICE_CFG.console-backup"
     export EMU_CONSOLE_CFG="$DEVICE_CFG.console-backup"
-    # Apply each "[section] key = value" line from the per-game file
-    awk '
-    NR == FNR {
-        if (substr($0,1,1) == "[") {
-            i = index($0, "]")
-            if (i > 0) {
-                sec = substr($0, 2, i - 2)
-                rest = substr($0, i + 1)
-                sub(/^ +/, "", rest)
-                j = index(rest, " = ")
-                if (j > 0) {
-                    k = substr(rest, 1, j - 1)
-                    v = substr(rest, j + 3)
-                    ovr[sec, k] = v
-                    okeys[sec, k] = 1
-                }
-            }
-        }
-        next
-    }
-    /^\[/ {
-        gsub(/[\[\]]/, "")
-        cur = $0
-    }
-    {
-        if (cur != "" && index($0, " = ") > 0) {
-            k = $0
-            sub(/ = .*/, "", k)
-            if (okeys[cur, k]) {
-                print k " = " ovr[cur, k]
-                delete okeys[cur, k]
-                next
-            }
-        }
-        print
-    }
-    ' "$PER_GAME_CFG" "$DEVICE_CFG" > "$DEVICE_CFG.tmp" && \
-    mv "$DEVICE_CFG.tmp" "$DEVICE_CFG"
+    "$BIN_DIR/ini" merge "$DEVICE_CFG" "$PER_GAME_CFG"
 fi
 
 # Determine anisotropy for --set: per-game override > user console setting > device default
 ANISO_SET=""
 if [ -f "$PER_GAME_CFG" ]; then
-    PER_GAME_ANISO=$(awk '/^\[Video-GLideN64\] anisotropy = / { sub(/.*= /, ""); print; exit }' "$PER_GAME_CFG" 2>/dev/null)
+    PER_GAME_ANISO=$("$BIN_DIR/ini" get "$PER_GAME_CFG" "Video-GLideN64" "anisotropy" 2>/dev/null)
 fi
 if [ -n "$PER_GAME_ANISO" ]; then
     # Per-game override takes highest priority
@@ -387,7 +344,8 @@ command -v sleepmon.elf >/dev/null && sleepmon.elf &
 
 # Launch from BIN_DIR so core library resolves via ./
 cd "$BIN_DIR"
-./mupen64plus --fullscreen --resolution "$DEVICE_RESOLUTION" \
+env LD_LIBRARY_PATH="$M64P_LD_LIBRARY_PATH" LD_PRELOAD="$M64P_LD_PRELOAD" \
+    ./mupen64plus --fullscreen --resolution "$DEVICE_RESOLUTION" \
     --configdir "$DEVICE_CONFIG_DIR" \
     --datadir "$BIN_DIR" \
     --plugindir "$BIN_DIR" \

--- a/overlay/emu_frontend.c
+++ b/overlay/emu_frontend.c
@@ -414,50 +414,6 @@ static void load_button_mappings_from_file(const char* path) {
 		// Check for section header
 		if (line[0] == '[') {
 			in_input_section = (strstr(line, "[Input-SDL-Control1]") != NULL);
-			// Also check per-game flat format: [Input-SDL-Control1] key = value
-			if (in_input_section && strchr(line, '=')) {
-				// Flat format — parse inline
-				char* rest = strstr(line, "]");
-				if (rest) {
-					rest++;
-					while (*rest == ' ') rest++;
-					char* eq = strchr(rest, '=');
-					if (eq) {
-						*eq = '\0';
-						char* key = rest;
-						while (key[strlen(key)-1] == ' ') key[strlen(key)-1] = '\0';
-						char* val = eq + 1;
-						while (*val == ' ') val++;
-						// Check for _mod suffix
-						int klen = (int)strlen(key);
-						if (klen > 4 && strcmp(key + klen - 4, "_mod") == 0) {
-							char base_key[128];
-							snprintf(base_key, sizeof(base_key), "%.*s", klen - 4, key);
-							for (int i = 0; i < N64_REMAP_COUNT; i++) {
-								if (strcmp(s_buttonMappings[i].cfg_key, base_key) == 0) {
-									s_buttonMappings[i].mod = atoi(val);
-									break;
-								}
-							}
-						} else {
-							for (int i = 0; i < N64_REMAP_COUNT; i++) {
-								if (strcmp(s_buttonMappings[i].cfg_key, key) == 0) {
-									int phys, is_ax, ax_dir;
-									if (parse_binding_string(val, &phys, &is_ax, &ax_dir)) {
-										s_buttonMappings[i].physical = phys;
-										s_buttonMappings[i].is_axis = is_ax;
-										s_buttonMappings[i].axis_dir = ax_dir;
-										s_buttonMappings[i].mod = 0;
-									}
-									break;
-								}
-							}
-						}
-					}
-				}
-				in_input_section = false; // flat format is one-line
-				continue;
-			}
 			continue;
 		}
 		if (!in_input_section) continue;
@@ -839,44 +795,45 @@ static void write_shortcuts_to_ini(const char* ini_path) {
 	fclose(f);
 }
 
-// Persistence: write button mappings in per-game flat format
+// Persistence: write button mappings in standard INI format
 static void write_bindings_per_game(FILE* f) {
 	if (!f) return;
+	fprintf(f, "\n[Input-SDL-Control1]\n");
 	for (int i = 0; i < N64_REMAP_COUNT; i++) {
 		N64ButtonMapping* m = &s_buttonMappings[i];
 		if (m->physical < 0) {
-			fprintf(f, "[Input-SDL-Control1] %s = \"\"\n", m->cfg_key);
+			fprintf(f, "%s = \"\"\n", m->cfg_key);
 		} else if (m->is_axis) {
-			fprintf(f, "[Input-SDL-Control1] %s = \"axis(%d%s)\"\n", m->cfg_key,
+			fprintf(f, "%s = \"axis(%d%s)\"\n", m->cfg_key,
 					m->physical, m->axis_dir > 0 ? "+" : "-");
 		} else {
-			fprintf(f, "[Input-SDL-Control1] %s = \"button(%d)\"\n", m->cfg_key, m->physical);
+			fprintf(f, "%s = \"button(%d)\"\n", m->cfg_key, m->physical);
 		}
 		if (m->mod != 0)
-			fprintf(f, "[Input-SDL-Control1] %s_mod = %d\n", m->cfg_key, m->mod);
+			fprintf(f, "%s_mod = %d\n", m->cfg_key, m->mod);
 	}
 }
 
-// Persistence: write shortcuts in per-game flat format
+// Persistence: write shortcuts in standard INI format
 static void write_shortcuts_per_game(FILE* f) {
 	if (!f) return;
+	fprintf(f, "\n[NextUI-Shortcuts]\n");
 	for (int i = 0; i < SHORTCUT_COUNT; i++) {
 		ShortcutBinding* s = &s_shortcuts[i];
 		if (s->physical < 0) {
-			fprintf(f, "[NextUI-Shortcuts] %s = \"\"\n", s->key);
+			fprintf(f, "%s = \"\"\n", s->key);
 		} else if (s->is_axis) {
-			fprintf(f, "[NextUI-Shortcuts] %s = \"axis(%d%s)\"\n", s->key,
+			fprintf(f, "%s = \"axis(%d%s)\"\n", s->key,
 					s->physical, s->axis_dir > 0 ? "+" : "-");
 		} else {
-			fprintf(f, "[NextUI-Shortcuts] %s = \"button(%d)\"\n", s->key, s->physical);
+			fprintf(f, "%s = \"button(%d)\"\n", s->key, s->physical);
 		}
 		if (s->mod != 0)
-			fprintf(f, "[NextUI-Shortcuts] %s_mod = %d\n", s->key, s->mod);
+			fprintf(f, "%s_mod = %d\n", s->key, s->mod);
 	}
 }
 
-// Load shortcuts from a config file (INI or per-game flat format).
-// Handles both [NextUI-Shortcuts] section format and flat "[NextUI-Shortcuts] key = val".
+// Load shortcuts from a config file (standard INI with [NextUI-Shortcuts] section).
 static void load_shortcuts_from_file(const char* path) {
 	if (!path || path[0] == '\0') return;
 	FILE* f = fopen(path, "r");
@@ -888,49 +845,7 @@ static void load_shortcuts_from_file(const char* path) {
 		while (len > 0 && (line[len-1] == '\n' || line[len-1] == '\r' || line[len-1] == ' '))
 			line[--len] = '\0';
 		if (line[0] == '[') {
-			// Check for flat format: [NextUI-Shortcuts] key = value
-			if (strstr(line, "[NextUI-Shortcuts]")) {
-				char* rest = strstr(line, "]");
-				if (rest) {
-					rest++;
-					while (*rest == ' ') rest++;
-					if (*rest != '\0') {
-						// Flat format — parse inline key = value
-						char* eq = strchr(rest, '=');
-						if (eq) {
-							*eq = '\0';
-							char* key = rest;
-							while (key[strlen(key)-1] == ' ') key[strlen(key)-1] = '\0';
-							char* val = eq + 1;
-							while (*val == ' ') val++;
-							// Check if this is a _mod key
-							int klen = (int)strlen(key);
-							if (klen > 4 && strcmp(key + klen - 4, "_mod") == 0) {
-								char base_key[128];
-								snprintf(base_key, sizeof(base_key), "%.*s", klen - 4, key);
-								ShortcutBinding* s = find_shortcut(base_key);
-								if (s) s->mod = atoi(val);
-							} else {
-								ShortcutBinding* s = find_shortcut(key);
-								if (s) {
-									int phys, is_ax, ax_dir;
-									if (parse_binding_string(val, &phys, &is_ax, &ax_dir)) {
-										s->physical = phys;
-										s->is_axis = is_ax;
-										s->axis_dir = ax_dir;
-										s->mod = 0; // reset mod; _mod line follows if needed
-									}
-								}
-							}
-						}
-						in_section = false;
-						continue;
-					}
-				}
-				in_section = true;
-			} else {
-				in_section = false;
-			}
+			in_section = (strstr(line, "[NextUI-Shortcuts]") != NULL);
 			continue;
 		}
 		if (!in_section) continue;

--- a/overlay/emu_overlay_cfg.c
+++ b/overlay/emu_overlay_cfg.c
@@ -766,7 +766,9 @@ int emu_ovl_cfg_read_per_game(EmuOvlConfig* cfg, const char* path) {
 	if (!f)
 		return 0; // missing file is OK — no per-game overrides
 
+	char current_section[EMU_OVL_MAX_STR] = "";
 	char line[512];
+
 	while (fgets(line, sizeof(line), f)) {
 		// Trim trailing whitespace/newline
 		int len = (int)strlen(line);
@@ -775,42 +777,41 @@ int emu_ovl_cfg_read_per_game(EmuOvlConfig* cfg, const char* path) {
 		if (len == 0 || line[0] == '#')
 			continue;
 
-		// Parse "[section] key = value" OR bare "key = value"
-		char pg_section[EMU_OVL_MAX_STR] = "";
-		char* kv_start = line;
+		// Section header
 		if (line[0] == '[') {
 			char* close = strchr(line, ']');
 			if (close) {
 				int slen = (int)(close - line - 1);
 				if (slen > 0 && slen < EMU_OVL_MAX_STR) {
-					memcpy(pg_section, line + 1, slen);
-					pg_section[slen] = '\0';
+					memcpy(current_section, line + 1, slen);
+					current_section[slen] = '\0';
+				} else {
+					current_section[0] = '\0';
 				}
-				kv_start = close + 1;
-				while (*kv_start == ' ') kv_start++;
 			}
+			continue;
 		}
 
-		char* eq = strchr(kv_start, '=');
+		if (current_section[0] == '\0')
+			continue;
+
+		char* eq = strchr(line, '=');
 		if (!eq)
 			continue;
 		*eq = '\0';
-		char* key = strip(kv_start);
+		char* key = strip(line);
 		char* val = strip(eq + 1);
 
-		// Match against config items
+		// Match against config items in the current section
 		for (int s = 0; s < cfg->section_count; s++) {
 			EmuOvlSection* sec = &cfg->sections[s];
 			for (int i = 0; i < sec->item_count; i++) {
 				EmuOvlItem* item = &sec->items[i];
 				if (strcmp(item->key, key) != 0)
 					continue;
-				// If the per-game line has a [section], verify it matches
-				if (pg_section[0] != '\0') {
-					const char* target = get_ini_section_for_item(cfg, sec, item);
-					if (strcmp(target, pg_section) != 0)
-						continue;
-				}
+				const char* target = get_ini_section_for_item(cfg, sec, item);
+				if (strcmp(target, current_section) != 0)
+					continue;
 
 				int v;
 				switch (item->type) {
@@ -859,35 +860,33 @@ int emu_ovl_cfg_write_per_game(EmuOvlConfig* cfg, const char* path) {
 		return -1;
 	}
 
-	// Full snapshot: write every item's staged_value in [section] key = value form.
+	// Collect unique INI section names in first-seen order.
+	const char* seen[EMU_OVL_MAX_SECTIONS * EMU_OVL_MAX_ITEMS];
+	int seen_count = 0;
 	for (int s = 0; s < cfg->section_count; s++) {
 		EmuOvlSection* sec = &cfg->sections[s];
 		for (int i = 0; i < sec->item_count; i++) {
-			EmuOvlItem* item = &sec->items[i];
-			const char* ini_sec = get_ini_section_for_item(cfg, sec, item);
-			switch (item->type) {
-			case EMU_OVL_TYPE_BOOL:
-				fprintf(f, "[%s] %s = %s\n", ini_sec, item->key,
-						item->staged_value ? "True" : "False");
-				break;
-			case EMU_OVL_TYPE_CYCLE:
-				if (item->is_string_cycle) {
-					int idx = item->staged_value;
-					if (idx < 0 || idx >= item->value_count)
-						idx = 0;
-					fprintf(f, "[%s] %s = \"%s\"\n", ini_sec, item->key,
-							item->string_values[idx]);
-					break;
-				}
-				/* fall through for numeric cycles */
-			case EMU_OVL_TYPE_INT:
-				if (item->float_scale > 0)
-					fprintf(f, "[%s] %s = %f\n", ini_sec, item->key,
-							(double)item->staged_value / item->float_scale);
-				else
-					fprintf(f, "[%s] %s = %d\n", ini_sec, item->key,
-							item->staged_value);
-				break;
+			const char* ini_sec = get_ini_section_for_item(cfg, sec, &sec->items[i]);
+			int found = 0;
+			for (int j = 0; j < seen_count; j++) {
+				if (strcmp(seen[j], ini_sec) == 0) { found = 1; break; }
+			}
+			if (!found)
+				seen[seen_count++] = ini_sec;
+		}
+	}
+
+	// Write standard INI: [Section] header, then key = value lines.
+	for (int si = 0; si < seen_count; si++) {
+		if (si > 0) fprintf(f, "\n");
+		fprintf(f, "[%s]\n", seen[si]);
+		for (int s = 0; s < cfg->section_count; s++) {
+			EmuOvlSection* sec = &cfg->sections[s];
+			for (int i = 0; i < sec->item_count; i++) {
+				EmuOvlItem* item = &sec->items[i];
+				if (strcmp(get_ini_section_for_item(cfg, sec, item), seen[si]) != 0)
+					continue;
+				write_item_value(f, item);
 			}
 		}
 	}

--- a/overlay/emu_overlay_cfg.h
+++ b/overlay/emu_overlay_cfg.h
@@ -64,15 +64,14 @@ void emu_ovl_cfg_free(EmuOvlConfig* cfg);
 int emu_ovl_cfg_read_ini(EmuOvlConfig* cfg, const char* ini_path);
 int emu_ovl_cfg_write_ini(EmuOvlConfig* cfg, const char* ini_path);
 
-// Per-game overrides: read a flat "[section] key = value" file and overlay
-// matching items' current_value/staged_value on top of whatever was already
-// loaded via emu_ovl_cfg_read_ini. Returns 0 on success, -1 on error (file
-// missing is not an error — returns 0 with no changes).
+// Per-game overrides: read a standard INI file and overlay matching items'
+// current_value/staged_value on top of whatever was already loaded via
+// emu_ovl_cfg_read_ini. Returns 0 on success, -1 on error (file missing
+// is not an error — returns 0 with no changes).
 int emu_ovl_cfg_read_per_game(EmuOvlConfig* cfg, const char* path);
 
-// Scoped write: writes ALL items (full snapshot) to `path` in the flat
-// "[section] key = value" per-game format. Used for both "Save for Game"
-// and (via a separate path) "Save for Console".
+// Scoped write: writes ALL items (full snapshot) to `path` in standard INI
+// format with [Section] headers. Used for "Save for Game".
 int emu_ovl_cfg_write_per_game(EmuOvlConfig* cfg, const char* path);
 
 void emu_ovl_cfg_reset_staged(EmuOvlConfig* cfg);

--- a/tools/ini/Makefile
+++ b/tools/ini/Makefile
@@ -1,0 +1,24 @@
+CC       = $(CROSS_COMPILE)gcc
+# INI_MAX_LINE=1024: mupen64plus.cfg has comment lines >200 chars (inih default)
+# INI_ALLOW_INLINE_COMMENTS=0: prevent semicolons in values being treated as comments
+DEFINES  = -DINI_MAX_LINE=1024 -DINI_ALLOW_INLINE_COMMENTS=0
+CFLAGS   = -Os -s -Wl,--gc-sections -I./lib $(DEFINES)
+CFLAGS_NATIVE = -Os -I./lib $(DEFINES)
+TARGET   = ini
+SOURCES  = ini.c lib/ini.c
+PRODUCT  = build/$(TARGET)
+
+all:
+	mkdir -p build
+	$(CC) $(SOURCES) -o $(PRODUCT) $(CFLAGS)
+
+# Build and test natively (for CI / local dev)
+test: build-native
+	./test.sh
+
+build-native:
+	mkdir -p build
+	$(CC) $(SOURCES) -o $(PRODUCT) $(CFLAGS_NATIVE)
+
+clean:
+	rm -rf build

--- a/tools/ini/ini.c
+++ b/tools/ini/ini.c
@@ -1,0 +1,289 @@
+/*
+ * ini — lightweight CLI for reading and merging INI files.
+ *
+ * Usage:
+ *   ini get  <file> <section> <key>    Print value, exit 0=found 1=missing 2=error
+ *   ini merge <base> <overlay>         Merge overlay values into base (atomic write)
+ *
+ * Built on top of inih (https://github.com/benhoyt/inih), BSD-3-Clause.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <unistd.h>
+
+#include "lib/ini.h"
+
+/* ── helpers ─────────────────────────────────────────────────────────────── */
+
+/* Strip leading/trailing whitespace in-place, return pointer into buf. */
+static char *strip(char *s) {
+    while (*s && isspace((unsigned char)*s)) s++;
+    char *end = s + strlen(s);
+    while (end > s && isspace((unsigned char)*(end - 1))) end--;
+    *end = '\0';
+    return s;
+}
+
+/* Remove surrounding double-quotes if present. */
+static char *strip_quotes(char *s) {
+    size_t len = strlen(s);
+    if (len >= 2 && s[0] == '"' && s[len - 1] == '"') {
+        s[len - 1] = '\0';
+        return s + 1;
+    }
+    return s;
+}
+
+/* ── get ─────────────────────────────────────────────────────────────────── */
+
+typedef struct {
+    const char *section;
+    const char *key;
+    char value[4096];
+    int found;
+} GetCtx;
+
+static int get_handler(void *user, const char *section,
+                       const char *name, const char *value) {
+    GetCtx *ctx = (GetCtx *)user;
+    if (strcmp(section, ctx->section) == 0 && strcmp(name, ctx->key) == 0) {
+        snprintf(ctx->value, sizeof(ctx->value), "%s", value);
+        ctx->found = 1;
+    }
+    return 1; /* keep parsing — last match wins */
+}
+
+static int cmd_get(const char *file, const char *section, const char *key) {
+    GetCtx ctx;
+    ctx.section = section;
+    ctx.key     = key;
+    ctx.value[0] = '\0';
+    ctx.found   = 0;
+
+    int err = ini_parse(file, get_handler, &ctx);
+    if (err == -1) {
+        fprintf(stderr, "ini: cannot open %s\n", file);
+        return 2;
+    }
+    /* err > 0 means a parse error on that line — we still return any value
+       that was successfully parsed before the error. */
+
+    if (!ctx.found)
+        return 1;
+
+    char *out = strip_quotes(ctx.value);
+    printf("%s\n", out);
+    return 0;
+}
+
+/* ── merge ───────────────────────────────────────────────────────────────── */
+
+#define MERGE_MAX_ENTRIES 512
+#define MERGE_MAX_LINE   4096
+
+typedef struct {
+    char section[256];
+    char key[256];
+    char value[1024];
+    int  written;
+} MergeEntry;
+
+typedef struct {
+    MergeEntry entries[MERGE_MAX_ENTRIES];
+    int count;
+} MergeCtx;
+
+static int merge_handler(void *user, const char *section,
+                         const char *name, const char *value) {
+    MergeCtx *ctx = (MergeCtx *)user;
+    if (ctx->count >= MERGE_MAX_ENTRIES)
+        return 0; /* stop parsing */
+
+    /* If the same section+key already exists (duplicate), update it. */
+    for (int i = 0; i < ctx->count; i++) {
+        if (strcmp(ctx->entries[i].section, section) == 0 &&
+            strcmp(ctx->entries[i].key, name) == 0) {
+            snprintf(ctx->entries[i].value, sizeof(ctx->entries[i].value),
+                     "%s", value);
+            return 1;
+        }
+    }
+
+    MergeEntry *e = &ctx->entries[ctx->count++];
+    snprintf(e->section, sizeof(e->section), "%s", section);
+    snprintf(e->key,     sizeof(e->key),     "%s", name);
+    snprintf(e->value,   sizeof(e->value),   "%s", value);
+    e->written = 0;
+    return 1;
+}
+
+/* Flush unwritten entries for a given section. */
+static void flush_section(FILE *out, MergeCtx *ctx, const char *section) {
+    for (int i = 0; i < ctx->count; i++) {
+        MergeEntry *e = &ctx->entries[i];
+        if (!e->written && strcmp(e->section, section) == 0) {
+            fprintf(out, "%s = %s\n", e->key, e->value);
+            e->written = 1;
+        }
+    }
+}
+
+/* Extract key name from a "key = value" line. Returns pointer into buf
+   (modifies buf by NUL-terminating after the key). Returns NULL if no
+   '=' found. */
+static char *extract_key(char *buf) {
+    char *eq = strchr(buf, '=');
+    if (!eq) {
+        eq = strchr(buf, ':');
+        if (!eq) return NULL;
+    }
+    *eq = '\0';
+    return strip(buf);
+}
+
+static int cmd_merge(const char *base_path, const char *overlay_path) {
+    /* 1. Parse overlay into entry list */
+    MergeCtx ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    int err = ini_parse(overlay_path, merge_handler, &ctx);
+    if (err == -1) {
+        fprintf(stderr, "ini: cannot open overlay %s\n", overlay_path);
+        return 1;
+    }
+    if (ctx.count == 0) return 0; /* nothing to merge */
+
+    /* 2. Open base for reading */
+    FILE *base = fopen(base_path, "r");
+    if (!base) {
+        fprintf(stderr, "ini: cannot open base %s\n", base_path);
+        return 1;
+    }
+
+    /* 3. Write to temp file */
+    char tmp_path[4096];
+    snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", base_path);
+    FILE *out = fopen(tmp_path, "w");
+    if (!out) {
+        fprintf(stderr, "ini: cannot create %s\n", tmp_path);
+        fclose(base);
+        return 1;
+    }
+
+    char line[MERGE_MAX_LINE];
+    char cur_section[256] = "";
+
+    while (fgets(line, sizeof(line), base)) {
+        /* Make a mutable copy for parsing */
+        char copy[MERGE_MAX_LINE];
+        snprintf(copy, sizeof(copy), "%s", line);
+        char *trimmed = strip(copy);
+
+        if (trimmed[0] == '[') {
+            /* Section header — flush pending entries for the previous section */
+            if (cur_section[0] != '\0')
+                flush_section(out, &ctx, cur_section);
+
+            /* Extract new section name */
+            char *end = strchr(trimmed, ']');
+            if (end) {
+                *end = '\0';
+                snprintf(cur_section, sizeof(cur_section), "%s", trimmed + 1);
+            }
+            fputs(line, out);
+        } else if (trimmed[0] == '#' || trimmed[0] == ';' || trimmed[0] == '\0') {
+            /* Comment or blank — pass through */
+            fputs(line, out);
+        } else {
+            /* Potential key=value line */
+            char *key = extract_key(copy);
+            if (key) {
+                /* Check overlay for a matching entry */
+                int replaced = 0;
+                for (int i = 0; i < ctx.count; i++) {
+                    MergeEntry *e = &ctx.entries[i];
+                    if (!e->written &&
+                        strcmp(e->section, cur_section) == 0 &&
+                        strcmp(e->key, key) == 0) {
+                        fprintf(out, "%s = %s\n", e->key, e->value);
+                        e->written = 1;
+                        replaced = 1;
+                        break;
+                    }
+                }
+                if (!replaced)
+                    fputs(line, out);
+            } else {
+                fputs(line, out);
+            }
+        }
+    }
+
+    /* Flush remaining entries for the last section */
+    if (cur_section[0] != '\0')
+        flush_section(out, &ctx, cur_section);
+
+    /* Append entries for sections that don't exist in the base file */
+    char appended_sections[MERGE_MAX_ENTRIES][256];
+    int  appended_count = 0;
+
+    for (int i = 0; i < ctx.count; i++) {
+        MergeEntry *e = &ctx.entries[i];
+        if (e->written) continue;
+
+        /* Check if we already emitted this section header */
+        int found = 0;
+        for (int j = 0; j < appended_count; j++) {
+            if (strcmp(appended_sections[j], e->section) == 0) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            fprintf(out, "\n[%s]\n", e->section);
+            snprintf(appended_sections[appended_count++], 256, "%s", e->section);
+            /* Write all entries for this new section */
+            flush_section(out, &ctx, e->section);
+        }
+    }
+
+    fclose(base);
+    fclose(out);
+
+    /* 4. Atomic replace */
+    if (rename(tmp_path, base_path) != 0) {
+        perror("ini: rename failed");
+        unlink(tmp_path);
+        return 1;
+    }
+    return 0;
+}
+
+/* ── main ────────────────────────────────────────────────────────────────── */
+
+static void usage(void) {
+    fprintf(stderr,
+        "Usage:\n"
+        "  ini get  <file> <section> <key>\n"
+        "  ini merge <base> <overlay>\n");
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) { usage(); return 2; }
+
+    if (strcmp(argv[1], "get") == 0) {
+        if (argc != 5) { usage(); return 2; }
+        return cmd_get(argv[2], argv[3], argv[4]);
+    }
+
+    if (strcmp(argv[1], "merge") == 0) {
+        if (argc != 4) { usage(); return 2; }
+        return cmd_merge(argv[2], argv[3]);
+    }
+
+    usage();
+    return 2;
+}

--- a/tools/ini/lib/LICENSE.txt
+++ b/tools/ini/lib/LICENSE.txt
@@ -1,0 +1,27 @@
+
+The "inih" library is distributed under the New BSD license:
+
+Copyright (c) 2009, Ben Hoyt
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Ben Hoyt nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY BEN HOYT ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL BEN HOYT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tools/ini/lib/ini.c
+++ b/tools/ini/lib/ini.c
@@ -1,0 +1,333 @@
+/* inih -- simple .INI file parser
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (C) 2009-2025, Ben Hoyt
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <assert.h>
+
+#include "ini.h"
+
+#if !INI_USE_STACK
+#if INI_CUSTOM_ALLOCATOR
+#include <stddef.h>
+void* ini_malloc(size_t size);
+void ini_free(void* ptr);
+void* ini_realloc(void* ptr, size_t size);
+#else
+#include <stdlib.h>
+#define ini_malloc malloc
+#define ini_free free
+#define ini_realloc realloc
+#endif
+#endif
+
+#define MAX_SECTION 50
+#define MAX_NAME 50
+
+/* Used by ini_parse_string() to keep track of string parsing state. */
+typedef struct {
+    const char* ptr;
+    size_t num_left;
+} ini_parse_string_ctx;
+
+/* Strip whitespace chars off end of given string, in place. end must be a
+   pointer to the NUL terminator at the end of the string. Return s. */
+static char* ini_rstrip(char* s, char* end)
+{
+    while (end > s && isspace((unsigned char)(*--end)))
+        *end = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* ini_lskip(const char* s)
+{
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char (of chars) or inline comment in given string,
+   or pointer to NUL at end of string if neither found. Inline comment must
+   be prefixed by a whitespace character to register as a comment. */
+static char* ini_find_chars_or_comment(const char* s, const char* chars)
+{
+#if INI_ALLOW_INLINE_COMMENTS
+    int was_space = 0;
+    while (*s && (!chars || !strchr(chars, *s)) &&
+           !(was_space && strchr(INI_INLINE_COMMENT_PREFIXES, *s))) {
+        was_space = isspace((unsigned char)(*s));
+        s++;
+    }
+#else
+    while (*s && (!chars || !strchr(chars, *s))) {
+        s++;
+    }
+#endif
+    return (char*)s;
+}
+
+/* Similar to strncpy, but ensures dest (size bytes) is
+   NUL-terminated, and doesn't pad with NULs. */
+static char* ini_strncpy0(char* dest, const char* src, size_t size)
+{
+    /* Could use strncpy internally, but it causes gcc warnings (see issue #91) */
+    size_t i;
+    for (i = 0; i < size - 1 && src[i]; i++)
+        dest[i] = src[i];
+    dest[i] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user)
+{
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+    size_t max_line = INI_MAX_LINE;
+#else
+    char* line;
+    size_t max_line = INI_INITIAL_ALLOC;
+#endif
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+    char* new_line;
+#endif
+    char section[MAX_SECTION] = "";
+#if INI_ALLOW_MULTILINE
+    char prev_name[MAX_NAME] = "";
+#endif
+
+    size_t offset;
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+    char abyss[16];  /* Used to consume input when a line is too long. */
+    size_t abyss_len;
+
+    assert(reader != NULL);
+    assert(stream != NULL);
+    assert(handler != NULL);
+
+#if !INI_USE_STACK
+    line = (char*)ini_malloc(INI_INITIAL_ALLOC);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+#if INI_HANDLER_LINENO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#else
+#define HANDLER(u, s, n, v) handler(u, s, n, v)
+#endif
+
+    /* Scan through stream line by line */
+    while (reader(line, (int)max_line, stream) != NULL) {
+        offset = strlen(line);
+
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+        while (max_line < INI_MAX_LINE &&
+               offset == max_line - 1 && line[offset - 1] != '\n') {
+            max_line *= 2;
+            if (max_line > INI_MAX_LINE)
+                max_line = INI_MAX_LINE;
+            new_line = ini_realloc(line, max_line);
+            if (!new_line) {
+                ini_free(line);
+                return -2;
+            }
+            line = new_line;
+            if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
+                break;
+            offset += strlen(line + offset);
+        }
+#endif
+
+        lineno++;
+
+        /* If line exceeded INI_MAX_LINE bytes, discard till end of line. */
+        if (offset == max_line - 1 && line[offset - 1] != '\n') {
+            while (reader(abyss, sizeof(abyss), stream) != NULL) {
+                if (!error)
+                    error = lineno;
+                abyss_len = strlen(abyss);
+                if (abyss_len > 0 && abyss[abyss_len - 1] == '\n')
+                    break;
+            }
+        }
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+                           (unsigned char)start[1] == 0xBB &&
+                           (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = ini_rstrip(ini_lskip(start), line + offset);
+
+        if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
+            /* Start-of-line comment */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+#if INI_ALLOW_INLINE_COMMENTS
+            end = ini_find_chars_or_comment(start, NULL);
+            *end = '\0';
+            ini_rstrip(start, end);
+#endif
+            /* Non-blank line with leading whitespace, treat as continuation
+               of previous name's value (as per Python configparser). */
+            if (!HANDLER(user, section, prev_name, start) && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = ini_find_chars_or_comment(start + 1, "]");
+            if (*end == ']') {
+                *end = '\0';
+                ini_strncpy0(section, start + 1, sizeof(section));
+#if INI_ALLOW_MULTILINE
+                *prev_name = '\0';
+#endif
+#if INI_CALL_HANDLER_ON_NEW_SECTION
+                if (!HANDLER(user, section, NULL, NULL) && !error)
+                    error = lineno;
+#endif
+            }
+            else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        }
+        else if (*start) {
+            /* Not a comment, must be a name[=:]value pair */
+            end = ini_find_chars_or_comment(start, "=:");
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = ini_rstrip(start, end);
+                value = end + 1;
+#if INI_ALLOW_INLINE_COMMENTS
+                end = ini_find_chars_or_comment(value, NULL);
+                *end = '\0';
+#endif
+                value = ini_lskip(value);
+                ini_rstrip(value, end);
+
+#if INI_ALLOW_MULTILINE
+                ini_strncpy0(prev_name, name, sizeof(prev_name));
+#endif
+                /* Valid name[=:]value pair found, call handler */
+                if (!HANDLER(user, section, name, value) && !error)
+                    error = lineno;
+            }
+            else {
+                /* No '=' or ':' found on name[=:]value line */
+#if INI_ALLOW_NO_VALUE
+                *end = '\0';
+                name = ini_rstrip(start, end);
+                if (!HANDLER(user, section, name, NULL) && !error)
+                    error = lineno;
+#else
+                if (!error)
+                    error = lineno;
+#endif
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    ini_free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user)
+{
+    return ini_parse_stream((ini_reader)fgets, file, handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename, ini_handler handler, void* user)
+{
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, user);
+    fclose(file);
+    return error;
+}
+
+/* An ini_reader function to read the next line from a string buffer. This
+   is the fgets() equivalent used by ini_parse_string(). */
+static char* ini_reader_string(char* str, int num, void* stream) {
+    ini_parse_string_ctx* ctx = (ini_parse_string_ctx*)stream;
+    const char* ctx_ptr = ctx->ptr;
+    size_t ctx_num_left = ctx->num_left;
+    char* strp = str;
+    char c;
+
+    if (ctx_num_left == 0 || num < 2)
+        return NULL;
+
+    while (num > 1 && ctx_num_left != 0) {
+        c = *ctx_ptr++;
+        ctx_num_left--;
+        *strp++ = c;
+        if (c == '\n')
+            break;
+        num--;
+    }
+
+    *strp = '\0';
+    ctx->ptr = ctx_ptr;
+    ctx->num_left = ctx_num_left;
+    return str;
+}
+
+/* See documentation in header file. */
+int ini_parse_string(const char* string, ini_handler handler, void* user) {
+    return ini_parse_string_length(string, strlen(string), handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse_string_length(const char* string, size_t length,
+                            ini_handler handler, void* user) {
+    ini_parse_string_ctx ctx;
+
+    ctx.ptr = string;
+    ctx.num_left = length;
+    return ini_parse_stream((ini_reader)ini_reader_string, &ctx, handler,
+                            user);
+}

--- a/tools/ini/lib/ini.h
+++ b/tools/ini/lib/ini.h
@@ -1,0 +1,189 @@
+/* inih -- simple .INI file parser
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (C) 2009-2025, Ben Hoyt
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#ifndef INI_H
+#define INI_H
+
+/* Make this header file easier to include in C++ code */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/* Nonzero if ini_handler callback should accept lineno parameter. */
+#ifndef INI_HANDLER_LINENO
+#define INI_HANDLER_LINENO 0
+#endif
+
+/* Visibility symbols, required for Windows DLLs */
+#ifndef INI_API
+#if defined _WIN32 || defined __CYGWIN__
+#	ifdef INI_SHARED_LIB
+#		ifdef INI_SHARED_LIB_BUILDING
+#			define INI_API __declspec(dllexport)
+#		else
+#			define INI_API __declspec(dllimport)
+#		endif
+#	else
+#		define INI_API
+#	endif
+#else
+#	if defined(__GNUC__) && __GNUC__ >= 4
+#		define INI_API __attribute__ ((visibility ("default")))
+#	else
+#		define INI_API
+#	endif
+#endif
+#endif
+
+/* Typedef for prototype of handler function.
+
+   Note that even though the value parameter has type "const char*", the user
+   may cast to "char*" and modify its content, as the value is not used again
+   after the call to ini_handler. This is not true of section and name --
+   those must not be modified.
+*/
+#if INI_HANDLER_LINENO
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value,
+                           int lineno);
+#else
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value);
+#endif
+
+/* Typedef for prototype of fgets-style reader function. */
+typedef char* (*ini_reader)(char* str, int num, void* stream);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+INI_API int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+INI_API int ini_parse_file(FILE* file, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes an ini_reader function pointer instead of
+   filename. Used for implementing custom or string-based I/O (see also
+   ini_parse_string). */
+INI_API int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user);
+
+/* Same as ini_parse(), but takes a zero-terminated string with the INI data
+   instead of a file. Useful for parsing INI data from a network socket or
+   which is already in memory. */
+INI_API int ini_parse_string(const char* string, ini_handler handler, void* user);
+
+/* Same as ini_parse_string(), but takes a string and its length, avoiding
+   strlen(). Useful for parsing INI data from a network socket or which is
+   already in memory, or interfacing with C++ std::string_view. */
+INI_API int ini_parse_string_length(const char* string, size_t length, ini_handler handler, void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   configparser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See https://github.com/benhoyt/inih/issues/21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Chars that begin a start-of-line comment. Per Python configparser, allow
+   both ; and # comments at the start of a line by default. */
+#ifndef INI_START_COMMENT_PREFIXES
+#define INI_START_COMMENT_PREFIXES ";#"
+#endif
+
+/* Nonzero to allow inline comments (with valid inline comment characters
+   specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
+   Python 3.2+ configparser behaviour. */
+#ifndef INI_ALLOW_INLINE_COMMENTS
+#define INI_ALLOW_INLINE_COMMENTS 1
+#endif
+#ifndef INI_INLINE_COMMENT_PREFIXES
+#define INI_INLINE_COMMENT_PREFIXES ";"
+#endif
+
+/* Nonzero to use stack for line buffer, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Maximum line length for any line in INI file (stack or heap). Note that
+   this must be 3 more than the longest line (due to '\r', '\n', and '\0'). */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+/* Nonzero to allow heap line buffer to grow via realloc(), zero for a
+   fixed-size buffer of INI_MAX_LINE bytes. Only applies if INI_USE_STACK is
+   zero. */
+#ifndef INI_ALLOW_REALLOC
+#define INI_ALLOW_REALLOC 0
+#endif
+
+/* Initial size in bytes for heap line buffer. Only applies if INI_USE_STACK
+   is zero. */
+#ifndef INI_INITIAL_ALLOC
+#define INI_INITIAL_ALLOC 200
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Nonzero to call the handler at the start of each new section (with
+   name and value NULL). Default is to only call the handler on
+   each name=value pair. */
+#ifndef INI_CALL_HANDLER_ON_NEW_SECTION
+#define INI_CALL_HANDLER_ON_NEW_SECTION 0
+#endif
+
+/* Nonzero to allow a name without a value (no '=' or ':' on the line) and
+   call the handler with value NULL in this case. Default is to treat
+   no-value lines as an error. */
+#ifndef INI_ALLOW_NO_VALUE
+#define INI_ALLOW_NO_VALUE 0
+#endif
+
+/* Nonzero to use custom ini_malloc, ini_free, and ini_realloc memory
+   allocation functions (INI_USE_STACK must also be 0). These functions must
+   have the same signatures as malloc/free/realloc and behave in a similar
+   way. ini_realloc is only needed if INI_ALLOW_REALLOC is set. */
+#ifndef INI_CUSTOM_ALLOCATOR
+#define INI_CUSTOM_ALLOCATOR 0
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INI_H */

--- a/tools/ini/test.sh
+++ b/tools/ini/test.sh
@@ -1,0 +1,282 @@
+#!/bin/sh
+# Unit tests for the ini CLI tool.
+# Runs against a native-compiled binary (no cross-compilation needed).
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INI="$SCRIPT_DIR/build/ini"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    label="$1"; expected="$2"; actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        printf "FAIL: %s\n  expected: %s\n  actual:   %s\n" "$label" "$expected" "$actual"
+    fi
+}
+
+assert_exit() {
+    label="$1"; expected="$2"; actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        printf "FAIL: %s\n  expected exit %s, got %s\n" "$label" "$expected" "$actual"
+    fi
+}
+
+# ── Test fixtures ──────────────────────────────────────────────────────────
+
+cat > "$TMPDIR/basic.ini" << 'EOF'
+[Core]
+key1 = value1
+key2 = 42
+
+[Video]
+resolution = 1024x768
+anisotropy = 2
+EOF
+
+cat > "$TMPDIR/quoted.ini" << 'EOF'
+[UI-Console]
+VideoPlugin = "mupen64plus-video-GLideN64.so"
+AudioPlugin = "mupen64plus-audio-sdl.so"
+EOF
+
+cat > "$TMPDIR/sectionless.txt" << 'EOF'
+font=1
+screen=2
+lang=en
+EOF
+
+cat > "$TMPDIR/comments.ini" << 'EOF'
+# This is a comment
+[Section]
+# Another comment
+key = value
+; semicolon comment
+key2 = value2
+EOF
+
+cat > "$TMPDIR/duplicate_sections.ini" << 'EOF'
+[Core]
+key1 = first
+
+[Other]
+x = 1
+
+[Core]
+key1 = second
+key2 = added
+EOF
+
+cat > "$TMPDIR/whitespace.ini" << 'EOF'
+[Section]
+  key_with_spaces  =  value_with_spaces
+normal = clean
+EOF
+
+cat > "$TMPDIR/empty_value.ini" << 'EOF'
+[Section]
+empty =
+notempty = hello
+EOF
+
+# ── get: basic reads ───────────────────────────────────────────────────────
+
+result=$("$INI" get "$TMPDIR/basic.ini" "Core" "key1")
+assert_eq "get basic string" "value1" "$result"
+
+result=$("$INI" get "$TMPDIR/basic.ini" "Core" "key2")
+assert_eq "get basic int" "42" "$result"
+
+result=$("$INI" get "$TMPDIR/basic.ini" "Video" "resolution")
+assert_eq "get different section" "1024x768" "$result"
+
+result=$("$INI" get "$TMPDIR/basic.ini" "Video" "anisotropy")
+assert_eq "get anisotropy" "2" "$result"
+
+# ── get: quote stripping ──────────────────────────────────────────────────
+
+result=$("$INI" get "$TMPDIR/quoted.ini" "UI-Console" "VideoPlugin")
+assert_eq "get strips quotes" "mupen64plus-video-GLideN64.so" "$result"
+
+result=$("$INI" get "$TMPDIR/quoted.ini" "UI-Console" "AudioPlugin")
+assert_eq "get strips quotes 2" "mupen64plus-audio-sdl.so" "$result"
+
+# ── get: sectionless keys (empty section) ─────────────────────────────────
+
+result=$("$INI" get "$TMPDIR/sectionless.txt" "" "font")
+assert_eq "get sectionless font" "1" "$result"
+
+result=$("$INI" get "$TMPDIR/sectionless.txt" "" "screen")
+assert_eq "get sectionless screen" "2" "$result"
+
+result=$("$INI" get "$TMPDIR/sectionless.txt" "" "lang")
+assert_eq "get sectionless lang" "en" "$result"
+
+# ── get: missing key returns exit 1 ──────────────────────────────────────
+
+"$INI" get "$TMPDIR/basic.ini" "Core" "nonexistent" > /dev/null 2>&1 || rc=$?
+assert_exit "get missing key" "1" "${rc:-0}"
+
+# ── get: missing section returns exit 1 ──────────────────────────────────
+
+rc=0
+"$INI" get "$TMPDIR/basic.ini" "NoSection" "key1" > /dev/null 2>&1 || rc=$?
+assert_exit "get missing section" "1" "$rc"
+
+# ── get: missing file returns exit 2 ─────────────────────────────────────
+
+rc=0
+"$INI" get "$TMPDIR/nonexistent.ini" "Core" "key1" > /dev/null 2>&1 || rc=$?
+assert_exit "get missing file" "2" "$rc"
+
+# ── get: comments are skipped ────────────────────────────────────────────
+
+result=$("$INI" get "$TMPDIR/comments.ini" "Section" "key")
+assert_eq "get with comments" "value" "$result"
+
+result=$("$INI" get "$TMPDIR/comments.ini" "Section" "key2")
+assert_eq "get after semicolon comment" "value2" "$result"
+
+# ── get: duplicate sections (last value wins) ────────────────────────────
+
+result=$("$INI" get "$TMPDIR/duplicate_sections.ini" "Core" "key1")
+assert_eq "get duplicate section last wins" "second" "$result"
+
+result=$("$INI" get "$TMPDIR/duplicate_sections.ini" "Core" "key2")
+assert_eq "get key from second section block" "added" "$result"
+
+# ── get: whitespace handling ─────────────────────────────────────────────
+
+result=$("$INI" get "$TMPDIR/whitespace.ini" "Section" "key_with_spaces")
+assert_eq "get trims whitespace" "value_with_spaces" "$result"
+
+# ── get: empty value ─────────────────────────────────────────────────────
+
+result=$("$INI" get "$TMPDIR/empty_value.ini" "Section" "empty")
+assert_eq "get empty value" "" "$result"
+
+result=$("$INI" get "$TMPDIR/empty_value.ini" "Section" "notempty")
+assert_eq "get non-empty after empty" "hello" "$result"
+
+# ── merge: basic key replacement ─────────────────────────────────────────
+
+cp "$TMPDIR/basic.ini" "$TMPDIR/merge_base.ini"
+cat > "$TMPDIR/merge_overlay.ini" << 'EOF'
+[Core]
+key2 = 99
+
+[Video]
+anisotropy = 4
+EOF
+
+"$INI" merge "$TMPDIR/merge_base.ini" "$TMPDIR/merge_overlay.ini"
+result=$("$INI" get "$TMPDIR/merge_base.ini" "Core" "key2")
+assert_eq "merge replaces key" "99" "$result"
+
+result=$("$INI" get "$TMPDIR/merge_base.ini" "Core" "key1")
+assert_eq "merge preserves unmatched key" "value1" "$result"
+
+result=$("$INI" get "$TMPDIR/merge_base.ini" "Video" "anisotropy")
+assert_eq "merge replaces in other section" "4" "$result"
+
+result=$("$INI" get "$TMPDIR/merge_base.ini" "Video" "resolution")
+assert_eq "merge preserves unmatched in other section" "1024x768" "$result"
+
+# ── merge: add new keys to existing section ──────────────────────────────
+
+cp "$TMPDIR/basic.ini" "$TMPDIR/merge_add.ini"
+cat > "$TMPDIR/merge_add_overlay.ini" << 'EOF'
+[Core]
+new_key = new_value
+EOF
+
+"$INI" merge "$TMPDIR/merge_add.ini" "$TMPDIR/merge_add_overlay.ini"
+result=$("$INI" get "$TMPDIR/merge_add.ini" "Core" "new_key")
+assert_eq "merge adds new key" "new_value" "$result"
+
+result=$("$INI" get "$TMPDIR/merge_add.ini" "Core" "key1")
+assert_eq "merge preserves existing after add" "value1" "$result"
+
+# ── merge: add new section ───────────────────────────────────────────────
+
+cp "$TMPDIR/basic.ini" "$TMPDIR/merge_newsec.ini"
+cat > "$TMPDIR/merge_newsec_overlay.ini" << 'EOF'
+[NewSection]
+brand = new
+EOF
+
+"$INI" merge "$TMPDIR/merge_newsec.ini" "$TMPDIR/merge_newsec_overlay.ini"
+result=$("$INI" get "$TMPDIR/merge_newsec.ini" "NewSection" "brand")
+assert_eq "merge adds new section" "new" "$result"
+
+result=$("$INI" get "$TMPDIR/merge_newsec.ini" "Core" "key1")
+assert_eq "merge preserves original after new section" "value1" "$result"
+
+# ── merge: preserves comments ────────────────────────────────────────────
+
+cp "$TMPDIR/comments.ini" "$TMPDIR/merge_comments.ini"
+cat > "$TMPDIR/merge_comments_overlay.ini" << 'EOF'
+[Section]
+key = updated
+EOF
+
+"$INI" merge "$TMPDIR/merge_comments.ini" "$TMPDIR/merge_comments_overlay.ini"
+result=$("$INI" get "$TMPDIR/merge_comments.ini" "Section" "key")
+assert_eq "merge updates value with comments" "updated" "$result"
+
+# Verify comments are preserved in the file
+comment_count=$(grep -c '^#' "$TMPDIR/merge_comments.ini")
+assert_eq "merge preserves comment lines" "2" "$comment_count"
+
+# ── merge: empty overlay is no-op ────────────────────────────────────────
+
+cp "$TMPDIR/basic.ini" "$TMPDIR/merge_empty.ini"
+cat > "$TMPDIR/merge_empty_overlay.ini" << 'EOF'
+EOF
+
+"$INI" merge "$TMPDIR/merge_empty.ini" "$TMPDIR/merge_empty_overlay.ini"
+result=$("$INI" get "$TMPDIR/merge_empty.ini" "Core" "key1")
+assert_eq "merge empty overlay preserves base" "value1" "$result"
+
+# ── merge: quoted values ─────────────────────────────────────────────────
+
+cp "$TMPDIR/quoted.ini" "$TMPDIR/merge_quoted.ini"
+cat > "$TMPDIR/merge_quoted_overlay.ini" << 'EOF'
+[UI-Console]
+VideoPlugin = "mupen64plus-video-rice.so"
+EOF
+
+"$INI" merge "$TMPDIR/merge_quoted.ini" "$TMPDIR/merge_quoted_overlay.ini"
+result=$("$INI" get "$TMPDIR/merge_quoted.ini" "UI-Console" "VideoPlugin")
+assert_eq "merge quoted value" "mupen64plus-video-rice.so" "$result"
+
+# ── merge: missing overlay file returns error ────────────────────────────
+
+rc=0
+"$INI" merge "$TMPDIR/basic.ini" "$TMPDIR/nonexistent_overlay.ini" 2>/dev/null || rc=$?
+assert_exit "merge missing overlay" "1" "$rc"
+
+# ── usage: no args returns exit 2 ────────────────────────────────────────
+
+rc=0
+"$INI" 2>/dev/null || rc=$?
+assert_exit "no args exit code" "2" "$rc"
+
+rc=0
+"$INI" get 2>/dev/null || rc=$?
+assert_exit "get too few args" "2" "$rc"
+
+# ── Report ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- Vendors the [inih](https://github.com/benhoyt/inih) library and adds a self-contained `ini` CLI tool (`tools/ini/`) with `get` and `merge` subcommands, cross-compiled for both tg5040 and tg5050
- Replaces all awk-based INI parsing in `launch.sh` with the `ini` tool (anisotropy, VideoPlugin, font, per-game merge)
- Converts per-game overlay configs from the non-standard flat `[Section] key = value` format to proper INI with `[Section]` headers — updates both readers and writers in `emu_overlay_cfg.c` and `emu_frontend.c`
- Scopes `LD_LIBRARY_PATH` and `LD_PRELOAD` to only the mupen64plus binary invocation via `env`, keeping sleepmon.elf, syncsettings.elf, and taskset unaffected
- Adds 34 unit tests for the ini tool and a CI test job