### PR TITLE
feat: add tg5050 platform support

### DIFF
--- a/pak.json
+++ b/pak.json
@@ -6,7 +6,8 @@
   "repo_url": "https://github.com/josegonzalez/minui-n64-pak",
   "release_filename": "N64.pak.zip",
   "platforms": [
-    "tg5040"
+    "tg5040",
+    "tg5050"
   ],
   "launch": "launch.sh",
   "version": "0.6.0"


### PR DESCRIPTION
## Summary
- Adds `tg5050` to the `platforms` array in `pak.json`
- Build system, launch script, and dist directories already fully support tg5050 — this was the only missing piece