### PR TITLE
feat: add rg35xxplus platform support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,19 @@ NX_REDUX_TAG  := v1.1.1
 ZLIB_REPO     := https://github.com/madler/zlib
 ZLIB_TAG      := v1.3.2
 
-# 7-Zip standalone binary for ZIP/7Z ROM extraction. Pre-built AArch64 blob
+# 7-Zip standalone binary for ZIP/7Z ROM extraction. Pre-built blobs
 # published by the upstream 7-Zip project on GitHub. Sha256-verified.
 SEVENZ_VERSION := 26.00
 SEVENZ_TAG     := 2600
-SEVENZ_URL     := https://github.com/ip7z/7zip/releases/download/$(SEVENZ_VERSION)/7z$(SEVENZ_TAG)-linux-arm64.tar.xz
-SEVENZ_SHA256  := aa8f3d0a19af9674d3af0ec788b4e261501071e626cd75ad149f1c2c176cc87d
+SEVENZ_URL          := https://github.com/ip7z/7zip/releases/download/$(SEVENZ_VERSION)/7z$(SEVENZ_TAG)-linux-arm64.tar.xz
+SEVENZ_SHA256       := aa8f3d0a19af9674d3af0ec788b4e261501071e626cd75ad149f1c2c176cc87d
+SEVENZ_URL_ARM32    := https://github.com/ip7z/7zip/releases/download/$(SEVENZ_VERSION)/7z$(SEVENZ_TAG)-linux-arm.tar.xz
+SEVENZ_SHA256_ARM32 := 54755c32564c5966ab6ddeca376472e1d146b3b76648184f6a7797a7fab3af52
 
 # ── Docker toolchain images ───────────────────────────────────────────────────
-TG5040_IMAGE := ghcr.io/loveretro/tg5040-toolchain:latest
-TG5050_IMAGE := ghcr.io/loveretro/tg5050-toolchain:latest
+TG5040_IMAGE      := ghcr.io/loveretro/tg5040-toolchain:latest
+TG5050_IMAGE      := ghcr.io/loveretro/tg5050-toolchain:latest
+RG35XXPLUS_IMAGE  := savant/minui-toolchain:rg35xxplus
 
 # ── Paths ─────────────────────────────────────────────────────────────────────
 ROOT     := $(shell pwd)
@@ -62,6 +65,14 @@ CORE_FLAGS := CROSS_COMPILE=$(CROSS) HOST_CPU=$(HOST_CPU) \
 	USE_GLES=1 NEON=1 PIE=1 VULKAN=0 \
 	PKG_CONFIG=pkg-config OPTFLAGS="-O3 -mcpu=cortex-a53"
 
+# ── rg35xxplus cross-compile variables (ARM32) ───────────────────────────────
+CROSS_RG35XXPLUS    := arm-buildroot-linux-gnueabihf-
+HOST_CPU_RG35XXPLUS := arm
+
+CORE_FLAGS_RG35XXPLUS := CROSS_COMPILE=$(CROSS_RG35XXPLUS) HOST_CPU=$(HOST_CPU_RG35XXPLUS) \
+	USE_GLES=1 NEON=1 PIE=1 VULKAN=0 \
+	PKG_CONFIG=pkg-config OPTFLAGS="-O3 -marm -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard"
+
 # Docker run helper script — sets up env, then runs the given command.
 # Written to src/.docker-env.sh during clone phase.
 DOCKER_SCRIPT := /build/src/.docker-env.sh
@@ -70,8 +81,9 @@ DOCKER_SCRIPT := /build/src/.docker-env.sh
 # Top-level targets
 # ══════════════════════════════════════════════════════════════════════════════
 
-.PHONY: all build tg5040 tg5050 gliden64 rice dist clone patch patches clean \
-       ini-tg5040 ini-tg5050
+.PHONY: all build tg5040 tg5050 rg35xxplus gliden64 gliden64-arm32 rice dist clone patch patches clean \
+       ini-tg5040 ini-tg5050 ini-rg35xxplus rice-tg5040 rice-tg5050 rice-rg35xxplus \
+       dist-tg5040 dist-tg5050 dist-rg35xxplus
 
 build: clone patch
 	$(MAKE) tg5040
@@ -81,12 +93,17 @@ build: clone patch
 	$(MAKE) rice-tg5050
 	$(MAKE) ini-tg5040
 	$(MAKE) ini-tg5050
+	$(MAKE) rg35xxplus
+	$(MAKE) gliden64-arm32
+	$(MAKE) rice-rg35xxplus
+	$(MAKE) ini-rg35xxplus
 
-# Build both platforms sequentially, staging outputs between builds since they
+# Build all platforms sequentially, staging outputs between builds since they
 # share source directories.
 all:
 	$(MAKE) dist-tg5040
 	$(MAKE) dist-tg5050
+	$(MAKE) dist-rg35xxplus
 	@echo "=== Build complete. dist/N64.pak/ assembled ==="
 	@find $(DIST) -type f | sort
 
@@ -96,10 +113,13 @@ clone: $(SRC)/mupen64plus-core $(SRC)/mupen64plus-ui-console \
        $(SRC)/mupen64plus-audio-sdl $(SRC)/mupen64plus-input-sdl \
        $(SRC)/mupen64plus-rsp-hle $(SRC)/GLideN64 \
        $(SRC)/mupen64plus-video-rice $(SRC)/nx-redux \
-       $(SRC)/zlib $(SRC)/7zip/7zzs
+       $(SRC)/zlib $(SRC)/7zip/7zzs $(SRC)/7zip-arm32/7zzs
 	@# Write Docker env helper script (sets up cross-compile env, then exec's args)
 	@printf '#!/bin/bash\nsource ~/.bashrc\nexport PKG_CONFIG_PATH=/opt/aarch64-nextui-linux-gnu/aarch64-nextui-linux-gnu/libc/usr/lib/pkgconfig\nexport PKG_CONFIG_SYSROOT_DIR=/opt/aarch64-nextui-linux-gnu/aarch64-nextui-linux-gnu/libc\nexport SDL_CFLAGS="$$(pkg-config --cflags sdl2)"\nexport SDL_LDLIBS="$$(pkg-config --libs sdl2)"\nexec "$$@"\n' > $(SRC)/.docker-env.sh
 	@chmod +x $(SRC)/.docker-env.sh
+	@# rg35xxplus Docker env (ARM32 — no pkg-config available, hardcode SDL flags)
+	@printf '#!/bin/bash\nexport PATH=/opt/rg35xxplus-toolchain/usr/bin:$$PATH\nexport SDL_CFLAGS="-I/opt/rg35xxplus-toolchain/usr/arm-buildroot-linux-gnueabihf/sysroot/usr/include/SDL2 -D_REENTRANT"\nexport SDL_LDLIBS="-lSDL2"\nexec "$$@"\n' > $(SRC)/.docker-env-rg35xxplus.sh
+	@chmod +x $(SRC)/.docker-env-rg35xxplus.sh
 	@# Populate GLES headers and unmodified patches from nx-redux
 	@# (overlay/ sources are vendored in the repo — not pulled from nx-redux)
 	@mkdir -p $(ROOT)/include
@@ -150,6 +170,15 @@ $(SRC)/7zip/7zzs:
 	@chmod +x $(SRC)/7zip/7zzs
 	@rm -f $(SRC)/7zip/7z-linux-arm64.tar.xz
 
+$(SRC)/7zip-arm32/7zzs:
+	@mkdir -p $(SRC)/7zip-arm32
+	@echo "Fetching 7-Zip $(SEVENZ_VERSION) (arm32) from upstream…"
+	@curl -fsSL -o $(SRC)/7zip-arm32/7z-linux-arm.tar.xz $(SEVENZ_URL_ARM32)
+	@echo "$(SEVENZ_SHA256_ARM32)  $(SRC)/7zip-arm32/7z-linux-arm.tar.xz" | shasum -a 256 -c -
+	@tar -xJf $(SRC)/7zip-arm32/7z-linux-arm.tar.xz -C $(SRC)/7zip-arm32 7zzs License.txt
+	@chmod +x $(SRC)/7zip-arm32/7zzs
+	@rm -f $(SRC)/7zip-arm32/7z-linux-arm.tar.xz
+
 # ── Patch ─────────────────────────────────────────────────────────────────────
 
 PATCH_STAMP := $(SRC)/.patched
@@ -177,11 +206,19 @@ $(PATCH_STAMP): | clone
 DOCKER_RUN_5040 := docker run --rm -v $(ROOT):/build $(TG5040_IMAGE) $(DOCKER_SCRIPT)
 DOCKER_RUN_5050 := docker run --rm -v $(ROOT):/build $(TG5050_IMAGE) $(DOCKER_SCRIPT)
 
+DOCKER_SCRIPT_RG35XXPLUS := /build/src/.docker-env-rg35xxplus.sh
+DOCKER_RUN_RG35XXPLUS    := docker run --rm -v $(ROOT):/build $(RG35XXPLUS_IMAGE) $(DOCKER_SCRIPT_RG35XXPLUS)
+
 # Common plugin make flags (SDL_CFLAGS/SDL_LDLIBS exported by docker-env.sh)
 PLUGIN_MAKE := CROSS_COMPILE=$(CROSS) HOST_CPU=$(HOST_CPU) PIE=1 \
 	PKG_CONFIG=pkg-config \
 	APIDIR=/build/src/mupen64plus-core/src/api \
 	OPTFLAGS="-O3 -mcpu=cortex-a53"
+
+PLUGIN_MAKE_RG35XXPLUS := CROSS_COMPILE=$(CROSS_RG35XXPLUS) HOST_CPU=$(HOST_CPU_RG35XXPLUS) PIE=1 \
+	PKG_CONFIG=pkg-config \
+	APIDIR=/build/src/mupen64plus-core/src/api \
+	OPTFLAGS="-O3 -marm -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard"
 
 # ── TG5040 build ──────────────────────────────────────────────────────────────
 
@@ -237,6 +274,27 @@ tg5050-input: $(PATCH_STAMP)
 tg5050-rsp: $(PATCH_STAMP)
 	$(DOCKER_RUN_5050) bash -c 'cd /build/src/mupen64plus-rsp-hle/projects/unix && rm -rf _obj mupen64plus-rsp-hle.so && make -j$$(nproc) all $(PLUGIN_MAKE)'
 
+# ── rg35xxplus build (ARM32) ─────────────────────────────────────────────────
+
+.PHONY: rg35xxplus rg35xxplus-core rg35xxplus-ui rg35xxplus-audio rg35xxplus-input rg35xxplus-rsp
+
+rg35xxplus: rg35xxplus-core rg35xxplus-ui rg35xxplus-audio rg35xxplus-input rg35xxplus-rsp
+
+rg35xxplus-core: $(PATCH_STAMP)
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/src/mupen64plus-core/projects/unix && rm -rf _obj libmupen64plus.so* ../../src/asm_defines/asm_defines_gas.h ../../src/asm_defines/asm_defines_nasm.h && make -j$$(nproc) all $(CORE_FLAGS_RG35XXPLUS)'
+
+rg35xxplus-ui: $(PATCH_STAMP)
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/src/mupen64plus-ui-console/projects/unix && rm -rf _obj mupen64plus && make -j$$(nproc) all $(PLUGIN_MAKE_RG35XXPLUS) COREDIR="./" PLUGINDIR="./"'
+
+rg35xxplus-audio: $(PATCH_STAMP)
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/src/mupen64plus-audio-sdl/projects/unix && rm -rf _obj mupen64plus-audio-sdl.so && make -j$$(nproc) all $(PLUGIN_MAKE_RG35XXPLUS)'
+
+rg35xxplus-input: $(PATCH_STAMP)
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/src/mupen64plus-input-sdl/projects/unix && rm -rf _obj mupen64plus-input-sdl.so && make -j$$(nproc) all $(PLUGIN_MAKE_RG35XXPLUS)'
+
+rg35xxplus-rsp: $(PATCH_STAMP)
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/src/mupen64plus-rsp-hle/projects/unix && rm -rf _obj mupen64plus-rsp-hle.so && make -j$$(nproc) all $(PLUGIN_MAKE_RG35XXPLUS)'
+
 # ── GLideN64 (shared — built with tg5040 toolchain) ──────────────────────────
 
 .PHONY: gliden64
@@ -251,15 +309,36 @@ gliden64: $(PATCH_STAMP)
 	cp $(SRC)/zlib/libz.a $(SRC)/GLideN64/src/GLideNHQ/lib/libz.a
 	$(DOCKER_RUN_5040) bash -c 'cd /build/src/GLideN64/src && mkdir -p build && cd build && cmake -DCMAKE_TOOLCHAIN_FILE=../../toolchain-aarch64.cmake -DMUPENPLUSAPI=ON -DEGL=ON -DMESA=ON -DNEON_OPT=ON -DCRC_ARMV8=ON .. && make -j$$(nproc) mupen64plus-video-GLideN64'
 
+# ── GLideN64 ARM32 (rg35xxplus toolchain, separate build dir) ────────────────
+
+.PHONY: gliden64-arm32
+
+gliden64-arm32: $(PATCH_STAMP) tg5050-libpng-headers
+	@# Cross-compile zlib for ARM32 (separate copy of source to avoid conflicts)
+	@if [ ! -d $(SRC)/zlib-arm32 ]; then cp -r $(SRC)/zlib $(SRC)/zlib-arm32; fi
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/src/zlib-arm32 && [ -f libz.a ] || (make distclean 2>/dev/null; CC=arm-buildroot-linux-gnueabihf-gcc AR=arm-buildroot-linux-gnueabihf-ar RANLIB=arm-buildroot-linux-gnueabihf-ranlib CFLAGS="-marm -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard" ./configure --static && make -j$$(nproc))'
+	@# Cross-compile libpng for ARM32 (uses libpng source from tg5050-libpng-headers)
+	@if [ ! -d $(SRC)/libpng-arm32 ]; then cp -r $(LIBPNG_DIR) $(SRC)/libpng-arm32; fi
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/src/libpng-arm32 && [ -f libpng16.a ] || (CC=arm-buildroot-linux-gnueabihf-gcc AR=arm-buildroot-linux-gnueabihf-ar RANLIB=arm-buildroot-linux-gnueabihf-ranlib CFLAGS="-marm -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -I/build/src/zlib-arm32" LDFLAGS="-L/build/src/zlib-arm32" ./configure --host=arm-buildroot-linux-gnueabihf --prefix=/tmp/libpng-arm32 --enable-static --disable-shared && make -j$$(nproc))'
+	@# Replace bundled static libs with ARM32 versions
+	cp $(SRC)/libpng-arm32/.libs/libpng16.a $(SRC)/GLideN64/src/GLideNHQ/lib/libpng.a
+	cp $(SRC)/zlib-arm32/libz.a $(SRC)/GLideN64/src/GLideNHQ/lib/libz.a
+	@# Generate ARM32 CMake toolchain file
+	@printf 'set(CMAKE_SYSTEM_NAME Linux)\nset(CMAKE_SYSTEM_PROCESSOR arm)\n\nset(TOOLCHAIN_ROOT /opt/rg35xxplus-toolchain/usr)\nset(SYSROOT $${TOOLCHAIN_ROOT}/arm-buildroot-linux-gnueabihf/sysroot)\n\nset(CMAKE_C_COMPILER $${TOOLCHAIN_ROOT}/bin/arm-buildroot-linux-gnueabihf-gcc)\nset(CMAKE_CXX_COMPILER $${TOOLCHAIN_ROOT}/bin/arm-buildroot-linux-gnueabihf-g++)\n\nset(CMAKE_C_FLAGS "$${CMAKE_C_FLAGS} -marm -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard")\nset(CMAKE_CXX_FLAGS "$${CMAKE_CXX_FLAGS} -marm -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard")\n\nset(CMAKE_FIND_ROOT_PATH $${SYSROOT} $${SYSROOT}/usr)\nset(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\nset(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)\nset(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)\n\ninclude_directories(/build/include)\ninclude_directories($${SYSROOT}/usr/include)\nlink_directories($${SYSROOT}/usr/lib)\n\nset(PNG_LIBRARY /build/src/libpng-arm32/.libs/libpng16.a)\nset(PNG_PNG_INCLUDE_DIR /build/src/libpng-arm32)\nset(ZLIB_LIBRARY /build/src/zlib-arm32/libz.a)\nset(ZLIB_INCLUDE_DIR /build/src/zlib-arm32)\n\nset(FREETYPE_INCLUDE_DIRS $${SYSROOT}/usr/include/freetype2)\nset(FREETYPE_LIBRARIES $${SYSROOT}/usr/lib/libfreetype.so)\nset(FREETYPE_FOUND TRUE)\n\nset(SDL_TTF_INCLUDE_DIRS $${SYSROOT}/usr/include/SDL2)\nset(SDL_TTF_LIBRARIES $${SYSROOT}/usr/lib/libSDL2_ttf.so)\n' > $(SRC)/GLideN64/toolchain-arm32.cmake
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/src/GLideN64/src && mkdir -p build-arm32 && cd build-arm32 && cmake -DCMAKE_TOOLCHAIN_FILE=../../toolchain-arm32.cmake -DMUPENPLUSAPI=ON -DEGL=ON -DMESA=ON -DNEON_OPT=ON -DCRC_ARMV8=OFF .. && make -j$$(nproc) mupen64plus-video-GLideN64'
+
 # ── Rice video plugin (built per-platform toolchain) ─────────────────────────
 
-.PHONY: rice-tg5040 rice-tg5050
+.PHONY: rice-tg5040 rice-tg5050 rice-rg35xxplus
 
 rice-tg5040: $(PATCH_STAMP)
 	$(DOCKER_RUN_5040) bash -c 'cd /build/src/mupen64plus-video-rice/projects/unix && rm -rf _obj mupen64plus-video-rice.so && make -j$$(nproc) all $(PLUGIN_MAKE) USE_GLES=1'
 
 rice-tg5050: $(PATCH_STAMP) tg5050-libpng-headers
 	$(DOCKER_RUN_5050) bash -c 'cd /build/src/mupen64plus-video-rice/projects/unix && rm -rf _obj mupen64plus-video-rice.so && make -j$$(nproc) all $(PLUGIN_MAKE) USE_GLES=1 CPPFLAGS="-I/build/include" LIBPNG_CFLAGS="-I/build/src/libpng-headers/libpng-1.6.37" LIBPNG_LDLIBS="-lpng16 -lz"'
+
+rice-rg35xxplus: $(PATCH_STAMP)
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/src/mupen64plus-video-rice/projects/unix && rm -rf _obj mupen64plus-video-rice.so && make -j$$(nproc) all $(PLUGIN_MAKE_RG35XXPLUS) USE_GLES=1'
 
 # ── INI CLI tool (pure C, no SDK dependencies) ──────────────────────────────
 
@@ -273,11 +352,14 @@ ini-tg5050:
 	mkdir -p $(ROOT)/tools/ini/dist/tg5050
 	cp $(ROOT)/tools/ini/build/ini $(ROOT)/tools/ini/dist/tg5050/ini
 
+ini-rg35xxplus:
+	$(DOCKER_RUN_RG35XXPLUS) bash -c 'cd /build/tools/ini && make clean all CROSS_COMPILE=$(CROSS_RG35XXPLUS)'
+	mkdir -p $(ROOT)/tools/ini/dist/rg35xxplus
+	cp $(ROOT)/tools/ini/build/ini $(ROOT)/tools/ini/dist/rg35xxplus/ini
+
 # ── Dist assembly ─────────────────────────────────────────────────────────────
 
-.PHONY: dist dist-tg5040 dist-tg5050
-
-# Shared data/config files copied into each platform dir
+# Shared data/config files copied into each platform dir (ARM64)
 define DIST_COMMON
 	cp $(CONFIG)/shared/default.cfg $(1)/
 	cp $(CONFIG)/shared/overlay_settings.json $(1)/
@@ -291,7 +373,21 @@ define DIST_COMMON
 	cp pak.json $(1)/
 endef
 
-dist: dist-tg5040 dist-tg5050
+# Shared data/config files for rg35xxplus (ARM32 GLideN64 + 7zip)
+define DIST_COMMON_RG35XXPLUS
+	cp $(CONFIG)/shared/default.cfg $(1)/
+	cp $(CONFIG)/shared/overlay_settings.json $(1)/
+	cp $(SRC)/GLideN64/src/build-arm32/plugin/Release/mupen64plus-video-GLideN64.so $(1)/
+	cp $(SRC)/mupen64plus-core/data/mupen64plus.ini    $(1)/
+	cp $(SRC)/mupen64plus-input-sdl/data/InputAutoCfg.ini $(1)/
+	cp $(SRC)/mupen64plus-core/data/mupencheat.txt     $(1)/
+	cp $(SRC)/mupen64plus-video-rice/data/RiceVideoLinux.ini $(1)/
+	cp $(SRC)/7zip-arm32/7zzs                          $(1)/
+	cp $(SRC)/7zip-arm32/License.txt                   $(1)/7zzs.LICENSE
+	cp pak.json $(1)/
+endef
+
+dist: dist-tg5040 dist-tg5050 dist-rg35xxplus
 	@echo "=== dist/N64.pak/ assembled ==="
 	@find $(DIST) -type f | sort
 
@@ -322,6 +418,20 @@ dist-tg5050:
 	cp $(ROOT)/tools/ini/dist/tg5050/ini $(DIST)/tg5050/
 	$(DOCKER_RUN_5050) install -m 0644 /opt/aarch64-nextui-linux-gnu/aarch64-nextui-linux-gnu/libc/usr/lib/libpng16.so.16.37.0 /build/dist/N64.pak/tg5050/libpng16.so.16
 	$(DOCKER_RUN_5050) install -m 0644 /opt/aarch64-nextui-linux-gnu/aarch64-nextui-linux-gnu/libc/usr/lib/libz.so.1.2.12 /build/dist/N64.pak/tg5050/libz.so.1
+
+dist-rg35xxplus:
+	mkdir -p $(DIST)/rg35xxplus
+	cp $(CONFIG)/shared/launch.sh $(DIST)/launch.sh
+	cp $(SRC)/mupen64plus-core/projects/unix/libmupen64plus.so.2.0.0 $(DIST)/rg35xxplus/libmupen64plus.so.2
+	cp $(SRC)/mupen64plus-ui-console/projects/unix/mupen64plus       $(DIST)/rg35xxplus/
+	cp $(SRC)/mupen64plus-audio-sdl/projects/unix/mupen64plus-audio-sdl.so $(DIST)/rg35xxplus/
+	cp $(SRC)/mupen64plus-input-sdl/projects/unix/mupen64plus-input-sdl.so $(DIST)/rg35xxplus/
+	cp $(SRC)/mupen64plus-rsp-hle/projects/unix/mupen64plus-rsp-hle.so     $(DIST)/rg35xxplus/
+	cp $(SRC)/mupen64plus-video-rice/projects/unix/mupen64plus-video-rice.so $(DIST)/rg35xxplus/
+	$(call DIST_COMMON_RG35XXPLUS,$(DIST)/rg35xxplus)
+	cp $(ROOT)/tools/ini/dist/rg35xxplus/ini $(DIST)/rg35xxplus/
+	$(DOCKER_RUN_RG35XXPLUS) install -m 0644 /opt/rg35xxplus-toolchain/usr/arm-buildroot-linux-gnueabihf/sysroot/usr/lib/libpng16.so.16.32.0 /build/dist/N64.pak/rg35xxplus/libpng16.so.16
+	$(DOCKER_RUN_RG35XXPLUS) install -m 0644 /opt/rg35xxplus-toolchain/usr/arm-buildroot-linux-gnueabihf/sysroot/usr/lib/libz.so.1.2.11 /build/dist/N64.pak/rg35xxplus/libz.so.1
 
 # ── Release ──────────────────────────────────────────────────────────────────
 

--- a/config/shared/launch.sh
+++ b/config/shared/launch.sh
@@ -33,6 +33,14 @@ case "$PLATFORM" in
         ORIG_CPU_MIN=$(cat /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 2>/dev/null)
         ORIG_CPU_MAX=$(cat /sys/devices/system/cpu/cpu4/cpufreq/scaling_max_freq 2>/dev/null)
         ;;
+    rg35xxplus)
+        ORIG_CPU1=$(cat /sys/devices/system/cpu/cpu1/online 2>/dev/null)
+        ORIG_CPU2=$(cat /sys/devices/system/cpu/cpu2/online 2>/dev/null)
+        ORIG_CPU3=$(cat /sys/devices/system/cpu/cpu3/online 2>/dev/null)
+        ORIG_CPU_GOV=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null)
+        ORIG_CPU_MIN=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 2>/dev/null)
+        ORIG_CPU_MAX=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq 2>/dev/null)
+        ;;
 esac
 
 # ── CPU / GPU setup (platform-specific) ──────────────────────────────────────
@@ -51,11 +59,25 @@ case "$PLATFORM" in
         # GPU: lock to performance for GLideN64 rendering
         echo performance >/sys/devices/platform/soc@3000000/1800000.gpu/devfreq/1800000.gpu/governor 2>/dev/null
         ;;
+    rg35xxplus)
+        # Bring all cores online (single cluster: cpu0-3 Cortex-A53, Allwinner H700)
+        echo 1 >/sys/devices/system/cpu/cpu1/online 2>/dev/null
+        echo 1 >/sys/devices/system/cpu/cpu2/online 2>/dev/null
+        echo 1 >/sys/devices/system/cpu/cpu3/online 2>/dev/null
+        ;;
 esac
 
 # ── Memory management: swap + VM tuning for hi-res texture loading ────────────
-SWAPFILE="/mnt/UDISK/n64_swap"
+case "$PLATFORM" in
+    rg35xxplus)
+        SWAPFILE="/mnt/sdcard/.swap/n64_swap"
+        ;;
+    *)
+        SWAPFILE="/mnt/UDISK/n64_swap"
+        ;;
+esac
 if [ ! -f "$SWAPFILE" ]; then
+    mkdir -p "$(dirname "$SWAPFILE")"
     dd if=/dev/zero of="$SWAPFILE" bs=1M count=512 2>/dev/null
     mkswap "$SWAPFILE" 2>/dev/null
 fi
@@ -95,6 +117,25 @@ case "$PLATFORM" in
         # Mali-G57 (tg5050) can handle level 2; PowerVR GE8300 (tg5040) cannot.
         DEVICE_ANISOTROPY=2
         LEGACY_CONFIG_DIR="$LEGACY_USERDATA_DIR/config/tg5050"
+        ;;
+    rg35xxplus)
+        # rg35xxplus family: DEVICE may be "cube", "wide", or "hdmi" (from
+        # hdmimon.sh). Default is standard RG35xx Plus at 640x480.
+        if [ "$DEVICE" = "hdmi" ]; then
+            DEVICE_CONFIG_DIR="$USERDATA_DIR/hdmi"
+            DEVICE_RESOLUTION="1280x720"
+        elif [ "$DEVICE" = "cube" ]; then
+            DEVICE_CONFIG_DIR="$USERDATA_DIR/cube"
+            DEVICE_RESOLUTION="720x720"
+        elif [ "$DEVICE" = "wide" ]; then
+            DEVICE_CONFIG_DIR="$USERDATA_DIR/wide"
+            DEVICE_RESOLUTION="720x480"
+        else
+            DEVICE_CONFIG_DIR="$USERDATA_DIR"
+            DEVICE_RESOLUTION="640x480"
+        fi
+        DEVICE_ANISOTROPY=0
+        LEGACY_CONFIG_DIR=""
         ;;
 esac
 MIGRATION_STAMP="$DEVICE_CONFIG_DIR/.migrated-from-shared"
@@ -378,6 +419,12 @@ case "$PLATFORM" in
         HELPER_MASK=0x3 # cpu0-1
         VIDEO_MASK=0x20 # cpu5
         ;;
+    rg35xxplus)
+        # cpu0-3 are all Cortex-A53 (Allwinner H700)
+        MAIN_MASK=1     # cpu0
+        HELPER_MASK=0xc # cpu2-3
+        VIDEO_MASK=2    # cpu1
+        ;;
 esac
 
 taskset -p $MAIN_MASK "$EMU_PID" 2>/dev/null
@@ -439,6 +486,14 @@ case "$PLATFORM" in
         [ -n "$ORIG_CPU_GOV" ] && echo "$ORIG_CPU_GOV" >/sys/devices/system/cpu/cpu4/cpufreq/scaling_governor 2>/dev/null
         [ -n "$ORIG_CPU_MIN" ] && echo "$ORIG_CPU_MIN" >/sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 2>/dev/null
         [ -n "$ORIG_CPU_MAX" ] && echo "$ORIG_CPU_MAX" >/sys/devices/system/cpu/cpu4/cpufreq/scaling_max_freq 2>/dev/null
+        ;;
+    rg35xxplus)
+        [ -n "$ORIG_CPU3" ] && echo "$ORIG_CPU3" >/sys/devices/system/cpu/cpu3/online 2>/dev/null
+        [ -n "$ORIG_CPU2" ] && echo "$ORIG_CPU2" >/sys/devices/system/cpu/cpu2/online 2>/dev/null
+        [ -n "$ORIG_CPU1" ] && echo "$ORIG_CPU1" >/sys/devices/system/cpu/cpu1/online 2>/dev/null
+        [ -n "$ORIG_CPU_GOV" ] && echo "$ORIG_CPU_GOV" >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null
+        [ -n "$ORIG_CPU_MIN" ] && echo "$ORIG_CPU_MIN" >/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 2>/dev/null
+        [ -n "$ORIG_CPU_MAX" ] && echo "$ORIG_CPU_MAX" >/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq 2>/dev/null
         ;;
 esac
 

--- a/pak.json
+++ b/pak.json
@@ -7,7 +7,8 @@
   "release_filename": "N64.pak.zip",
   "platforms": [
     "tg5040",
-    "tg5050"
+    "tg5050",
+    "rg35xxplus"
   ],
   "launch": "launch.sh",
   "version": "0.6.1"


### PR DESCRIPTION
Add build and runtime support for the Anbernic rg35xxplus device family (Allwinner H700, ARM32 Cortex-A53, Mali-G31). This includes multiple device variants: RG35xx Plus (640x480), RGcubexx (720x720), RG34xx (720x480), RG28xx, and HDMI output (1280x720).

Key changes:
- ARM32 cross-compilation using savant/minui-toolchain:rg35xxplus
- Separate GLideN64 ARM32 build (build-arm32/) with ARM32 zlib/libpng
- ARM32 7-Zip binary for ROM archive extraction
- Runtime device variant detection via DEVICE env var in launch.sh
- Platform-aware swap file path (/mnt/sdcard/.swap/ for rg35xxplus)
- Thread pinning matching tg5040 (same 4x Cortex-A53 topology)

Closes #2