### PR TITLE
fix: prevent crash from sectionless per-game config

### DIFF
--- a/overlay/emu_frontend.c
+++ b/overlay/emu_frontend.c
@@ -220,7 +220,7 @@ static void apply_input_mode(int mode) {
 }
 
 // Read the per-game input_mode from the per-game config file.
-// Returns 1 for dpad, 0 for joystick, -1 if file missing.
+// Returns 1 for dpad, 0 for joystick, -1 if file missing or key absent.
 static int read_input_mode_file(void) {
 	const char* path = get_per_game_path();
 	if (!path || path[0] == '\0') return -1;
@@ -228,23 +228,85 @@ static int read_input_mode_file(void) {
 	if (!f) return -1;
 	char line[128];
 	int value = -1;
+	bool in_section = false;
 	while (fgets(line, sizeof(line), f)) {
-		if (strncmp(line, "input_mode=", 11) == 0) {
-			value = (strncmp(line + 11, "dpad", 4) == 0) ? 1 : 0;
-			break;
+		char* trimmed = line;
+		while (*trimmed == ' ' || *trimmed == '\t') trimmed++;
+		if (trimmed[0] == '[') {
+			in_section = (strncmp(trimmed, "[NextUI-Input]", 14) == 0);
+			continue;
+		}
+		if (in_section && strncmp(trimmed, "input_mode", 10) == 0) {
+			char* eq = strchr(trimmed, '=');
+			if (eq) {
+				char* val = eq + 1;
+				while (*val == ' ') val++;
+				value = (strncmp(val, "dpad", 4) == 0) ? 1 : 0;
+				break;
+			}
 		}
 	}
 	fclose(f);
 	return value;
 }
 
-// Write input_mode to the per-game config file.
+// Write input_mode to the per-game config file, preserving other settings.
 static void write_input_mode_file(int value) {
 	const char* path = get_per_game_path();
 	if (!path || path[0] == '\0') return;
-	FILE* f = fopen(path, "w");
+
+	// Read existing content
+	char buf[4096] = "";
+	int len = 0;
+	FILE* f = fopen(path, "r");
+	if (f) {
+		len = (int)fread(buf, 1, sizeof(buf) - 1, f);
+		buf[len] = '\0';
+		fclose(f);
+	}
+
+	f = fopen(path, "w");
 	if (!f) return;
-	fprintf(f, "input_mode=%s\n", value ? "dpad" : "joystick");
+
+	const char* new_val = value ? "dpad" : "joystick";
+	bool written = false;
+	bool in_section = false;
+
+	if (len > 0) {
+		// Replay existing content, replacing the key if found
+		char* line = buf;
+		while (line && *line) {
+			char* eol = strchr(line, '\n');
+			char linebuf[512];
+			int llen;
+			if (eol) {
+				llen = (int)(eol - line);
+				if (llen >= (int)sizeof(linebuf)) llen = (int)sizeof(linebuf) - 1;
+				memcpy(linebuf, line, llen);
+				linebuf[llen] = '\0';
+				line = eol + 1;
+			} else {
+				snprintf(linebuf, sizeof(linebuf), "%s", line);
+				line = NULL;
+			}
+			char* trimmed = linebuf;
+			while (*trimmed == ' ' || *trimmed == '\t') trimmed++;
+			if (trimmed[0] == '[') {
+				in_section = (strncmp(trimmed, "[NextUI-Input]", 14) == 0);
+				fprintf(f, "%s\n", linebuf);
+			} else if (in_section && strncmp(trimmed, "input_mode", 10) == 0 && strchr(trimmed, '=')) {
+				fprintf(f, "input_mode = %s\n", new_val);
+				written = true;
+			} else {
+				fprintf(f, "%s\n", linebuf);
+			}
+		}
+	}
+
+	if (!written) {
+		// Section or key didn't exist — append
+		fprintf(f, "\n[NextUI-Input]\ninput_mode = %s\n", new_val);
+	}
 	fclose(f);
 }
 

--- a/patches/shared/mupen64plus-core.patch
+++ b/patches/shared/mupen64plus-core.patch
@@ -22,6 +22,36 @@ index 0a3c49b..183eead 100644
  /* local variables */
  static ptr_DebugCallback pDebugFunc = NULL;
  static ptr_StateCallback pStateFunc = NULL;
+diff --git a/src/api/config.c b/src/api/config.c
+index cff288d..05d7797 100644
+--- a/src/api/config.c
++++ b/src/api/config.c
+@@ -529,6 +529,11 @@ m64p_error ConfigInit(const char *ConfigDirOverride, const char *DataDirOverride
+                 break;
+ 
+             case INI_SECTION:
++                if (l.name == NULL || strlen(l.name) < 1)
++                {
++                    current_section = NULL;
++                    break;
++                }
+                 rval = ConfigOpenSection(l.name, (m64p_handle *) &current_section);
+                 if (rval != M64ERR_SUCCESS)
+                 {
+@@ -833,8 +838,11 @@ EXPORT int CALL ConfigHasUnsavedChanges(const char *SectionName)
+         curr_section = l_ConfigListActive;
+         while (curr_section != NULL)
+         {
+-            if (ConfigHasUnsavedChanges(curr_section->name))
+-                return 1;
++            if (curr_section->name != NULL && strlen(curr_section->name) > 0)
++            {
++                if (ConfigHasUnsavedChanges(curr_section->name))
++                    return 1;
++            }
+             curr_section = curr_section->next;
+             iNumActiveSections++;
+         }
 diff --git a/src/api/frontend.c b/src/api/frontend.c
 index 956f96f..b3d3235 100644
 --- a/src/api/frontend.c

--- a/tools/ini/ini.c
+++ b/tools/ini/ini.c
@@ -102,6 +102,10 @@ static int merge_handler(void *user, const char *section,
     if (ctx->count >= MERGE_MAX_ENTRIES)
         return 0; /* stop parsing */
 
+    /* Skip entries with no section — they would produce [] in the output */
+    if (section[0] == '\0')
+        return 1;
+
     /* If the same section+key already exists (duplicate), update it. */
     for (int i = 0; i < ctx->count; i++) {
         if (strcmp(ctx->entries[i].section, section) == 0 &&


### PR DESCRIPTION
## Summary

- `write_input_mode_file()` was truncating the per-game config and writing a bare `input_mode=joystick` with no INI section header. When `launch.sh` ran `ini merge`, inih assigned the sectionless key to section `""` and wrote `[]` into `mupen64plus.cfg`. `ConfigHasUnsavedChanges(NULL)` then hit infinite recursion on the empty-named section, causing a stack overflow crash.
- Fixes the root cause by writing `input_mode` under `[NextUI-Input]` with read-modify-write semantics
- Adds defense-in-depth: `ini merge` skips empty sections, `ConfigInit` skips `[]` headers, `ConfigHasUnsavedChanges` skips empty-named sections