### PR TITLE
perf: remove redundant SDL_JoystickUpdate() in check_menu_button()

### DIFF
--- a/overlay/emu_frontend.c
+++ b/overlay/emu_frontend.c
@@ -1609,7 +1609,6 @@ static void overlay_ensure_init(int w, int h) {
 }
 
 static bool check_menu_button(void) {
-	SDL_JoystickUpdate();
 	if (!s_joy) return false;
 
 	bool pressed = SDL_JoystickGetButton(s_joy, 8) != 0;


### PR DESCRIPTION
SDL_PumpEvents() is already called earlier in the same frame via check_power_button(), which updates joystick state. The extra SDL_JoystickUpdate() in check_menu_button() was an unnecessary syscall every rendered frame.