### PR TITLE
feat: prompt to save and restart for restart-required settings

### DIFF
--- a/config/shared/launch.sh
+++ b/config/shared/launch.sh
@@ -170,13 +170,6 @@ if [ -d "$LEGACY_SCREENSHOT_DIR" ]; then
 fi
 # ScreenshotPath is set via --sshotdir on the mupen64plus command line.
 
-# ── Auto-resume: check if NextUI game switcher requested a state load ─────────
-RESUME_SLOT=""
-if [ -f /tmp/resume_slot.txt ]; then
-    RESUME_SLOT=$(cat /tmp/resume_slot.txt)
-    rm /tmp/resume_slot.txt
-fi
-
 # ── Environment ───────────────────────────────────────────────────────────────
 export HOME="$USERDATA_PATH"
 export XDG_DATA_HOME="$DEVICE_CONFIG_DIR"
@@ -186,8 +179,6 @@ M64P_LD_LIBRARY_PATH="$BIN_DIR:$SDCARD_PATH/.system/$PLATFORM/lib:/usr/trimui/li
 M64P_LD_PRELOAD="libEGL.so"
 # Relative ROM path for auto_resume.txt (strip /mnt/SDCARD prefix)
 export EMU_ROM_PATH="${ROM#/mnt/SDCARD}"
-# Pass resume slot to emulator if game switcher requested it
-[ -n "$RESUME_SLOT" ] && export EMU_RESUME_SLOT="$RESUME_SLOT"
 
 # ── Overlay menu config ──────────────────────────────────────────────────────
 export EMU_OVERLAY_JSON="$BIN_DIR/overlay_settings.json"
@@ -240,36 +231,11 @@ mkdir -p "$MINUI_DIR"
 export EMU_OVERLAY_SCREENSHOT_DIR="$MINUI_DIR"
 export EMU_OVERLAY_ROMFILE="$ROM_BASE"
 
-# ── Per-game settings ────────────────────────────────────────────────────────
+# ── Per-game settings (paths are stable; overlay is re-applied per launch) ───
 PER_GAME_DIR="$DEVICE_CONFIG_DIR/per-game"
 mkdir -p "$PER_GAME_DIR"
 PER_GAME_CFG="$PER_GAME_DIR/$ROM_BASE.cfg"
 export EMU_PER_GAME_CFG="$PER_GAME_CFG"
-
-# If a per-game config exists, overlay its values onto mupen64plus.cfg for
-# this run. Back up the console config first so it can be restored on exit
-# and so the overlay can write Save for Console to the backup path.
-if [ -f "$PER_GAME_CFG" ]; then
-    cp "$DEVICE_CFG" "$DEVICE_CFG.console-backup"
-    export EMU_CONSOLE_CFG="$DEVICE_CFG.console-backup"
-    "$BIN_DIR/ini" merge "$DEVICE_CFG" "$PER_GAME_CFG"
-fi
-
-# Determine anisotropy for --set: per-game override > user console setting > device default
-ANISO_SET=""
-if [ -f "$PER_GAME_CFG" ]; then
-    PER_GAME_ANISO=$("$BIN_DIR/ini" get "$PER_GAME_CFG" "Video-GLideN64" "anisotropy" 2>/dev/null)
-fi
-if [ -n "$PER_GAME_ANISO" ]; then
-    # Per-game override takes highest priority
-    ANISO_SET="--set Video-GLideN64[anisotropy]=$PER_GAME_ANISO"
-elif [ "$CONSOLE_ANISOTROPY" != "$DEVICE_ANISOTROPY" ]; then
-    # User customised console anisotropy — don't override, let config file value win
-    ANISO_SET=""
-else
-    # No customisation — apply device-appropriate default
-    ANISO_SET="--set Video-GLideN64[anisotropy]=$DEVICE_ANISOTROPY"
-fi
 
 # D-pad↔joystick input mode is handled by trimui_inputd via flag files
 # in /tmp/trimui_inputd/. emu_frontend applies the per-game mode at init
@@ -278,7 +244,7 @@ fi
 # Runtime button remap file for immediate application in input-sdl
 export EMU_BUTTON_MAP_FILE="$PER_GAME_DIR/$ROM_BASE.buttons"
 
-# ── Archive extraction ───────────────────────────────────────────────────────
+# ── Archive extraction (one-time — extracted ROM path stable across restarts)
 # If the ROM is a .zip or .7z, extract the inner N64 ROM to a tmpfs directory
 # and hand that path to mupen64plus instead. We keep the *original* $ROM name
 # (archive name minus its .zip/.7z) as the extracted file's basename so the
@@ -333,91 +299,157 @@ case "$ROM" in
         ;;
 esac
 
-# ── Launch ────────────────────────────────────────────────────────────────────
-# Mute speaker before launch to prevent audio pop, then unmute after init
-echo 1 > /sys/class/speaker/mute 2>/dev/null || true
-(sleep 5; echo 0 > /sys/class/speaker/mute 2>/dev/null; command -v syncsettings.elf >/dev/null && syncsettings.elf) &
-SYNC_PID=$!
-
-# Start power button sleep/poweroff handler (if available — GLideN64 handles it natively)
+# Start power button sleep/poweroff handler (one-time; GLideN64 handles natively)
 command -v sleepmon.elf >/dev/null && sleepmon.elf &
 
-# Launch from BIN_DIR so core library resolves via ./
-cd "$BIN_DIR"
-env LD_LIBRARY_PATH="$M64P_LD_LIBRARY_PATH" LD_PRELOAD="$M64P_LD_PRELOAD" \
-    ./mupen64plus --fullscreen --resolution "$DEVICE_RESOLUTION" \
-    --configdir "$DEVICE_CONFIG_DIR" \
-    --datadir "$BIN_DIR" \
-    --plugindir "$BIN_DIR" \
-    --sshotdir "$SCREENSHOT_DIR" \
-    --cachedir "$DEVICE_CONFIG_DIR/cache" \
-    --set "Video-General[ScreenWidth]=$SCREEN_W" \
-    --set "Video-General[ScreenHeight]=$SCREEN_H" \
-    --set "Core[SaveSRAMPath]=$BATTERY_SAVE_DIR/" \
-    --set "Core[SaveStatePath]=$STATE_SAVE_DIR/" \
-    $ANISO_SET \
-    --gfx "$BIN_DIR/$GFX_PLUGIN" \
-    --audio mupen64plus-audio-sdl.so \
-    --input mupen64plus-input-sdl.so \
-    --rsp mupen64plus-rsp-hle.so \
-    "$ROM" > "$LOGS_PATH/$EMU_TAG.mupen64plus.txt" 2>&1 &
-EMU_PID=$!
-sleep 4
-
-# ── Thread pinning (platform-specific CPU topology) ──────────────────────────
-case "$PLATFORM" in
-    tg5040)
-        # cpu0-3 are all Cortex-A53 @ 2000 MHz
-        MAIN_MASK=1     # cpu0
-        HELPER_MASK=0xc # cpu2-3
-        VIDEO_MASK=2    # cpu1
-        ;;
-    tg5050)
-        # big.LITTLE: cpu4-5 BIG (A55), cpu0-1 LITTLE
-        MAIN_MASK=0x10  # cpu4
-        HELPER_MASK=0x3 # cpu0-1
-        VIDEO_MASK=0x20 # cpu5
-        ;;
-esac
-
-taskset -p $MAIN_MASK "$EMU_PID" 2>/dev/null
-
-# Pin known helper threads
-for TID in $(ls /proc/$EMU_PID/task/ 2>/dev/null); do
-    [ "$TID" = "$EMU_PID" ] && continue
-    TNAME=$(cat /proc/$EMU_PID/task/$TID/comm 2>/dev/null)
-    case "$TNAME" in
-        SDLAudioP2|SDLHotplug*|SDLTimer|mali-*|m64pwq)
-            taskset -p $HELPER_MASK "$TID" 2>/dev/null ;;
-    esac
-done
-
-# Find the busiest non-main mupen64plus thread (video thread) and pin it
-sleep 2
-BEST_TID=""
-BEST_UTIME=0
-for TID in $(ls /proc/$EMU_PID/task/ 2>/dev/null); do
-    [ "$TID" = "$EMU_PID" ] && continue
-    TNAME=$(cat /proc/$EMU_PID/task/$TID/comm 2>/dev/null)
-    [ "$TNAME" = "mupen64plus" ] || continue
-    UTIME=$(awk '{print $14}' /proc/$EMU_PID/task/$TID/stat 2>/dev/null)
-    UTIME=${UTIME:-0}
-    if [ "$UTIME" -gt "$BEST_UTIME" ]; then
-        BEST_UTIME=$UTIME
-        BEST_TID=$TID
+# ── Launch loop ──────────────────────────────────────────────────────────────
+# The overlay's "Save and Restart" feature drops /tmp/m64p_restart_requested
+# (and a temp save state at /tmp/m64p_restart_state.m64p), then stops the core.
+# We loop here to relaunch with the new config and auto-load the temp state,
+# so restart-required settings (CPU overclock, audio resampler, etc.) take
+# effect without bouncing the user back to the launcher.
+while true; do
+    # ── Auto-resume sources ─────────────────────────────────────────────────
+    # NextUI game switcher: /tmp/resume_slot.txt is created by NextUI before
+    # invoking us; rm-after-read makes it self-limiting to the first iteration.
+    unset EMU_RESUME_SLOT
+    if [ -f /tmp/resume_slot.txt ]; then
+        EMU_RESUME_SLOT=$(cat /tmp/resume_slot.txt)
+        rm /tmp/resume_slot.txt
+        export EMU_RESUME_SLOT
     fi
+    # Save-and-restart: load the temp state written before the previous iteration
+    # exited. emu_frontend reads EMU_RESUME_PATH on init and loads the file.
+    unset EMU_RESUME_PATH
+    if [ -f /tmp/m64p_restart_state.m64p ]; then
+        export EMU_RESUME_PATH=/tmp/m64p_restart_state.m64p
+    fi
+
+    # ── Per-game overlay onto mupen64plus.cfg (re-applied each iteration so
+    # newly saved per-game / console values take effect on restart) ─────────
+    if [ -f "$PER_GAME_CFG" ]; then
+        cp "$DEVICE_CFG" "$DEVICE_CFG.console-backup"
+        export EMU_CONSOLE_CFG="$DEVICE_CFG.console-backup"
+        "$BIN_DIR/ini" merge "$DEVICE_CFG" "$PER_GAME_CFG"
+    else
+        unset EMU_CONSOLE_CFG
+    fi
+
+    # Determine anisotropy for --set: per-game override > user console setting > device default
+    ANISO_SET=""
+    PER_GAME_ANISO=""
+    if [ -f "$PER_GAME_CFG" ]; then
+        PER_GAME_ANISO=$("$BIN_DIR/ini" get "$PER_GAME_CFG" "Video-GLideN64" "anisotropy" 2>/dev/null)
+    fi
+    if [ -n "$PER_GAME_ANISO" ]; then
+        # Per-game override takes highest priority
+        ANISO_SET="--set Video-GLideN64[anisotropy]=$PER_GAME_ANISO"
+    elif [ "$CONSOLE_ANISOTROPY" != "$DEVICE_ANISOTROPY" ]; then
+        # User customised console anisotropy — don't override, let config file value win
+        ANISO_SET=""
+    else
+        # No customisation — apply device-appropriate default
+        ANISO_SET="--set Video-GLideN64[anisotropy]=$DEVICE_ANISOTROPY"
+    fi
+
+    # ── Launch ──────────────────────────────────────────────────────────────
+    # Mute speaker before launch to prevent audio pop, then unmute after init
+    echo 1 > /sys/class/speaker/mute 2>/dev/null || true
+    (sleep 5; echo 0 > /sys/class/speaker/mute 2>/dev/null; command -v syncsettings.elf >/dev/null && syncsettings.elf) &
+    SYNC_PID=$!
+
+    # Launch from BIN_DIR so core library resolves via ./
+    cd "$BIN_DIR"
+    env LD_LIBRARY_PATH="$M64P_LD_LIBRARY_PATH" LD_PRELOAD="$M64P_LD_PRELOAD" \
+        ./mupen64plus --fullscreen --resolution "$DEVICE_RESOLUTION" \
+        --configdir "$DEVICE_CONFIG_DIR" \
+        --datadir "$BIN_DIR" \
+        --plugindir "$BIN_DIR" \
+        --sshotdir "$SCREENSHOT_DIR" \
+        --cachedir "$DEVICE_CONFIG_DIR/cache" \
+        --set "Video-General[ScreenWidth]=$SCREEN_W" \
+        --set "Video-General[ScreenHeight]=$SCREEN_H" \
+        --set "Core[SaveSRAMPath]=$BATTERY_SAVE_DIR/" \
+        --set "Core[SaveStatePath]=$STATE_SAVE_DIR/" \
+        $ANISO_SET \
+        --gfx "$BIN_DIR/$GFX_PLUGIN" \
+        --audio mupen64plus-audio-sdl.so \
+        --input mupen64plus-input-sdl.so \
+        --rsp mupen64plus-rsp-hle.so \
+        "$ROM" > "$LOGS_PATH/$EMU_TAG.mupen64plus.txt" 2>&1 &
+    EMU_PID=$!
+    sleep 4
+
+    # ── Thread pinning (platform-specific CPU topology) ─────────────────────
+    case "$PLATFORM" in
+        tg5040)
+            # cpu0-3 are all Cortex-A53 @ 2000 MHz
+            MAIN_MASK=1     # cpu0
+            HELPER_MASK=0xc # cpu2-3
+            VIDEO_MASK=2    # cpu1
+            ;;
+        tg5050)
+            # big.LITTLE: cpu4-5 BIG (A55), cpu0-1 LITTLE
+            MAIN_MASK=0x10  # cpu4
+            HELPER_MASK=0x3 # cpu0-1
+            VIDEO_MASK=0x20 # cpu5
+            ;;
+    esac
+
+    taskset -p $MAIN_MASK "$EMU_PID" 2>/dev/null
+
+    # Pin known helper threads
+    for TID in $(ls /proc/$EMU_PID/task/ 2>/dev/null); do
+        [ "$TID" = "$EMU_PID" ] && continue
+        TNAME=$(cat /proc/$EMU_PID/task/$TID/comm 2>/dev/null)
+        case "$TNAME" in
+            SDLAudioP2|SDLHotplug*|SDLTimer|mali-*|m64pwq)
+                taskset -p $HELPER_MASK "$TID" 2>/dev/null ;;
+        esac
+    done
+
+    # Find the busiest non-main mupen64plus thread (video thread) and pin it
+    sleep 2
+    BEST_TID=""
+    BEST_UTIME=0
+    for TID in $(ls /proc/$EMU_PID/task/ 2>/dev/null); do
+        [ "$TID" = "$EMU_PID" ] && continue
+        TNAME=$(cat /proc/$EMU_PID/task/$TID/comm 2>/dev/null)
+        [ "$TNAME" = "mupen64plus" ] || continue
+        UTIME=$(awk '{print $14}' /proc/$EMU_PID/task/$TID/stat 2>/dev/null)
+        UTIME=${UTIME:-0}
+        if [ "$UTIME" -gt "$BEST_UTIME" ]; then
+            BEST_UTIME=$UTIME
+            BEST_TID=$TID
+        fi
+    done
+    [ -n "$BEST_TID" ] && taskset -p $VIDEO_MASK "$BEST_TID" 2>/dev/null
+
+    # ── Wait for the emulator to exit ───────────────────────────────────────
+    wait $EMU_PID
+    kill $SYNC_PID 2>/dev/null || true
+
+    # Restore console-backup so the next iteration starts from a clean console
+    # cfg. If the user just did Save-and-Restart-Console while in game scope,
+    # handle_save_for_console wrote the new values into this backup, so the
+    # mv promotes them into mupen64plus.cfg before the next overlay step.
+    if [ -f "$DEVICE_CFG.console-backup" ]; then
+        mv "$DEVICE_CFG.console-backup" "$DEVICE_CFG"
+    fi
+
+    # If a Save-and-Restart was requested, loop and re-launch
+    if [ -f /tmp/m64p_restart_requested ]; then
+        rm /tmp/m64p_restart_requested
+        continue
+    fi
+    break
 done
-[ -n "$BEST_TID" ] && taskset -p $VIDEO_MASK "$BEST_TID" 2>/dev/null
 
 # ── Cleanup: restore all saved system settings ───────────────────────────────
-wait $EMU_PID
 killall sleepmon.elf 2>/dev/null || true
-kill $SYNC_PID 2>/dev/null || true
 
-# Restore console config backup if per-game overrides were applied
-if [ -f "$DEVICE_CFG.console-backup" ]; then
-    mv "$DEVICE_CFG.console-backup" "$DEVICE_CFG"
-fi
+# Discard the temporary save state (kept out of the user's regular save slots)
+rm -f /tmp/m64p_restart_state.m64p /tmp/m64p_restart_requested
 
 # Clean up trimui_inputd flag files so we don't leak d-pad remap state
 rm -f /tmp/trimui_inputd/input_dpad_to_joystick

--- a/config/shared/overlay_settings.json
+++ b/config/shared/overlay_settings.json
@@ -38,7 +38,8 @@
             "Sinc (Medium)",
             "Sinc (Best)"
           ],
-          "default": 3
+          "default": 3,
+          "restart_required": true
         }
       ]
     },
@@ -63,7 +64,8 @@
             "4x",
             "8x"
           ],
-          "default": 0
+          "default": 0,
+          "restart_required": true
         },
         {
           "key": "cpu_mode",
@@ -173,7 +175,8 @@
           "description": "Display frames per second (restart required)",
           "type": "bool",
           "default": false,
-          "plugin": "gliden64"
+          "plugin": "gliden64",
+          "restart_required": true
         },
         {
           "key": "ShowFPS",
@@ -182,7 +185,8 @@
           "type": "bool",
           "default": false,
           "plugin": "rice",
-          "ini_section": "Video-Rice"
+          "ini_section": "Video-Rice",
+          "restart_required": true
         },
         {
           "key": "ShowPercent",
@@ -190,7 +194,8 @@
           "description": "Display emulation speed percentage (restart required)",
           "type": "bool",
           "default": false,
-          "plugin": "gliden64"
+          "plugin": "gliden64",
+          "restart_required": true
         },
         {
           "key": "ShowVIS",
@@ -198,7 +203,8 @@
           "description": "Display VI interrupts per second (restart required)",
           "type": "bool",
           "default": false,
-          "plugin": "gliden64"
+          "plugin": "gliden64",
+          "restart_required": true
         }
       ]
     },
@@ -500,7 +506,8 @@
           "description": "Run video backend on a separate thread (restart required)",
           "type": "bool",
           "default": true,
-          "plugin": "gliden64"
+          "plugin": "gliden64",
+          "restart_required": true
         }
       ]
     },

--- a/overlay/emu_frontend.c
+++ b/overlay/emu_frontend.c
@@ -1062,6 +1062,22 @@ static void trigger_game_switcher(void) {
 	request_stop();
 }
 
+// Save a temporary state to /tmp (out of the user's save-state slots),
+// drop a marker so launch.sh re-launches mupen64plus, and stop the core.
+// launch.sh exports EMU_RESUME_PATH on the next iteration so the frontend
+// auto-loads the temp state, landing the user back where they were.
+// launch.sh is responsible for deleting the temp state on final exit.
+static void trigger_save_and_restart(void) {
+	const char* path = "/tmp/m64p_restart_state.m64p";
+	if (s_coreAPI.core_cmd) {
+		// format=1 = mupen64plus native save state, written to file at `path`
+		s_coreAPI.core_cmd(M64CMD_STATE_SAVE, 1, (void*)path);
+	}
+	FILE* f = fopen("/tmp/m64p_restart_requested", "w");
+	if (f) fclose(f);
+	request_stop();
+}
+
 // ---------------------------------------------------------------------------
 // Rewind (tmpfs ring buffer of save states)
 // ---------------------------------------------------------------------------
@@ -1547,6 +1563,16 @@ static void overlay_ensure_init(int w, int h) {
 			s_coreAPI.core_cmd(M64CMD_STATE_SET_SLOT, slot, NULL);
 			s_coreAPI.core_cmd(M64CMD_STATE_LOAD, 0, NULL);
 			unsetenv("EMU_RESUME_SLOT");
+		}
+
+		// Restart-resume: if relaunched from a "Save and Restart" action,
+		// load the temp state file written by trigger_save_and_restart().
+		// launch.sh owns the file's lifecycle (created here, removed on
+		// final exit), so we only load — never delete.
+		const char* resume_path = getenv("EMU_RESUME_PATH");
+		if (resume_path && resume_path[0] != '\0' && s_coreAPI.core_cmd) {
+			s_coreAPI.core_cmd(M64CMD_STATE_LOAD, 0, (void*)resume_path);
+			unsetenv("EMU_RESUME_PATH");
 		}
 
 		// Load cheats from mupencheat.txt for the current ROM
@@ -2231,6 +2257,14 @@ static void handle_overlay_action(EmuOvlAction action) {
 		break;
 	case EMU_OVL_ACTION_RESTORE_DEFAULTS:
 		handle_restore_defaults();
+		break;
+	case EMU_OVL_ACTION_SAVE_AND_RESTART_CONSOLE:
+		handle_save_for_console();
+		trigger_save_and_restart();
+		break;
+	case EMU_OVL_ACTION_SAVE_AND_RESTART_GAME:
+		handle_save_for_game();
+		trigger_save_and_restart();
 		break;
 	default:
 		break;

--- a/overlay/emu_overlay.c
+++ b/overlay/emu_overlay.c
@@ -532,17 +532,61 @@ bool emu_ovl_update(EmuOvl* ovl, EmuOvlInput* input) {
 		} else if (input->down) {
 			ovl->selected = (ovl->selected + 1) % count;
 		} else if (input->a) {
+			EmuOvlAction picked = EMU_OVL_ACTION_NONE;
 			switch (ovl->selected) {
-			case 0: ovl->action = EMU_OVL_ACTION_SAVE_CONSOLE; break;
-			case 1: ovl->action = EMU_OVL_ACTION_SAVE_GAME; break;
-			case 2: ovl->action = EMU_OVL_ACTION_RESTORE_DEFAULTS; break;
+			case 0: picked = EMU_OVL_ACTION_SAVE_CONSOLE; break;
+			case 1: picked = EMU_OVL_ACTION_SAVE_GAME; break;
+			case 2: picked = EMU_OVL_ACTION_RESTORE_DEFAULTS; break;
 			}
+			// If a Save was picked AND any dirty setting needs a restart,
+			// detour through the restart prompt instead of closing immediately.
+			if ((picked == EMU_OVL_ACTION_SAVE_CONSOLE ||
+				 picked == EMU_OVL_ACTION_SAVE_GAME) &&
+				emu_ovl_cfg_any_dirty_restart_required(ovl->config)) {
+				ovl->pending_save_action = picked;
+				ovl->state = EMU_OVL_STATE_RESTART_PROMPT;
+				ovl->selected = 0; // default to "Yes"
+				break;
+			}
+			ovl->action = picked;
 			// Return to main menu after action — emu_frontend handles the write
 			ovl->state = EMU_OVL_STATE_MAIN_MENU;
 			ovl->selected = 0;
 			break;
 		} else if (input->b || input->menu) {
 			ovl->state = EMU_OVL_STATE_MAIN_MENU;
+			ovl->selected = 0;
+			break;
+		}
+		break;
+	}
+
+	// ----- RESTART PROMPT (Yes/No after a Save with restart-required dirty) -----
+	case EMU_OVL_STATE_RESTART_PROMPT: {
+		int count = 2; // 0 = Yes, save and restart; 1 = No, just save
+		if (input->up) {
+			ovl->selected = (ovl->selected - 1 + count) % count;
+		} else if (input->down) {
+			ovl->selected = (ovl->selected + 1) % count;
+		} else if (input->a) {
+			if (ovl->selected == 0) {
+				// Yes — save and restart
+				ovl->action =
+					(ovl->pending_save_action == EMU_OVL_ACTION_SAVE_GAME)
+						? EMU_OVL_ACTION_SAVE_AND_RESTART_GAME
+						: EMU_OVL_ACTION_SAVE_AND_RESTART_CONSOLE;
+			} else {
+				// No — just save (settings will apply on next manual launch)
+				ovl->action = ovl->pending_save_action;
+			}
+			ovl->pending_save_action = EMU_OVL_ACTION_NONE;
+			ovl->state = EMU_OVL_STATE_MAIN_MENU;
+			ovl->selected = 0;
+			break;
+		} else if (input->b || input->menu) {
+			// Cancel — go back to Save Changes without saving
+			ovl->pending_save_action = EMU_OVL_ACTION_NONE;
+			ovl->state = EMU_OVL_STATE_SAVE_CHANGES;
 			ovl->selected = 0;
 			break;
 		}
@@ -1218,6 +1262,39 @@ static void render_save_changes(EmuOvl* ovl) {
 	draw_footer_hints(ovl, hints, 4);
 }
 
+static void render_restart_prompt(EmuOvl* ovl) {
+	EmuOvlRenderBackend* r = ovl->render;
+
+	draw_menu_bar(ovl, "Apply Restart-Required Settings?");
+
+	// Body text below the title bar — explains why this prompt appears.
+	const char* body =
+		"Some changed settings only take effect on relaunch.";
+	int body_y = PADDING_PX + S(PILL_SIZE) + S(2);
+	r->draw_text(body, PADDING_PX + S(BUTTON_PADDING), body_y,
+				 EMU_OVL_COLOR_GRAY, EMU_OVL_FONT_TINY);
+
+	// 2 rows: Yes (save and restart), No (just save)
+	static const char* items[] = {
+		"Yes, save and restart now",
+		"No, just save"
+	};
+	int row_h = S(PILL_SIZE);
+	int content_x = PADDING_PX;
+	int content_w = ovl->screen_w - PADDING_PX * 2;
+	int list_y = calc_centered_list_y(ovl, 2);
+
+	for (int i = 0; i < 2; i++) {
+		int iy = list_y + i * row_h;
+		bool sel = (i == ovl->selected);
+		draw_settings_row(ovl, content_x, iy, content_w, row_h,
+						  items[i], NULL, sel, false, EMU_OVL_FONT_LARGE);
+	}
+
+	const char* hints[] = {"B", "CANCEL", "A", "OKAY"};
+	draw_footer_hints(ovl, hints, 4);
+}
+
 void emu_ovl_render(EmuOvl* ovl) {
 	if (ovl->state == EMU_OVL_STATE_CLOSED)
 		return;
@@ -1244,6 +1321,9 @@ void emu_ovl_render(EmuOvl* ovl) {
 		break;
 	case EMU_OVL_STATE_SAVE_CHANGES:
 		render_save_changes(ovl);
+		break;
+	case EMU_OVL_STATE_RESTART_PROMPT:
+		render_restart_prompt(ovl);
 		break;
 	case EMU_OVL_STATE_CLOSED:
 		break;

--- a/overlay/emu_overlay.h
+++ b/overlay/emu_overlay.h
@@ -13,7 +13,8 @@ typedef enum {
 	EMU_OVL_STATE_SECTION_LIST,
 	EMU_OVL_STATE_SECTION_ITEMS,
 	EMU_OVL_STATE_CHEATS,
-	EMU_OVL_STATE_SAVE_CHANGES
+	EMU_OVL_STATE_SAVE_CHANGES,
+	EMU_OVL_STATE_RESTART_PROMPT // Yes/No: apply restart-required settings now?
 } EmuOvlState;
 
 typedef enum {
@@ -22,9 +23,11 @@ typedef enum {
 	EMU_OVL_ACTION_SAVE_STATE,
 	EMU_OVL_ACTION_LOAD_STATE,
 	EMU_OVL_ACTION_QUIT,
-	EMU_OVL_ACTION_SAVE_CONSOLE,    // Save Changes → Save for Console
-	EMU_OVL_ACTION_SAVE_GAME,       // Save Changes → Save for Game
-	EMU_OVL_ACTION_RESTORE_DEFAULTS // Save Changes → Restore Defaults
+	EMU_OVL_ACTION_SAVE_CONSOLE,             // Save Changes → Save for Console
+	EMU_OVL_ACTION_SAVE_GAME,                // Save Changes → Save for Game
+	EMU_OVL_ACTION_RESTORE_DEFAULTS,         // Save Changes → Restore Defaults
+	EMU_OVL_ACTION_SAVE_AND_RESTART_CONSOLE, // Save for Console + relaunch emulator
+	EMU_OVL_ACTION_SAVE_AND_RESTART_GAME     // Save for Game + relaunch emulator
 } EmuOvlAction;
 
 typedef struct {
@@ -80,6 +83,11 @@ typedef struct {
 
 	EmuOvlAction action;
 	int action_param;
+
+	// Tracks which save action is queued while the restart prompt is shown.
+	// Set to SAVE_CONSOLE or SAVE_GAME on entry to RESTART_PROMPT; emitted
+	// (with or without the _AND_RESTART_ variant) once the user answers.
+	EmuOvlAction pending_save_action;
 
 	EmuConfigScope scope; // current save scope (none/console/game)
 	int bind_capture;            // -1 = not capturing, >= 0 = remap row index

--- a/overlay/emu_overlay_cfg.c
+++ b/overlay/emu_overlay_cfg.c
@@ -193,6 +193,8 @@ static void parse_item(const cJSON* json_item, EmuOvlItem* item) {
 	item->current_value = item->default_value;
 	item->staged_value = item->default_value;
 	item->dirty = false;
+
+	item->restart_required = json_get_bool(json_item, "restart_required", false);
 }
 
 // Returns true if an item/section tagged `plugin` should be visible for `active_plugin`.
@@ -742,6 +744,19 @@ bool emu_ovl_cfg_has_changes(EmuOvlConfig* cfg) {
 		EmuOvlSection* sec = &cfg->sections[s];
 		for (int i = 0; i < sec->item_count; i++) {
 			if (sec->items[i].dirty)
+				return true;
+		}
+	}
+	return false;
+}
+
+bool emu_ovl_cfg_any_dirty_restart_required(EmuOvlConfig* cfg) {
+	if (!cfg)
+		return false;
+	for (int s = 0; s < cfg->section_count; s++) {
+		EmuOvlSection* sec = &cfg->sections[s];
+		for (int i = 0; i < sec->item_count; i++) {
+			if (sec->items[i].dirty && sec->items[i].restart_required)
 				return true;
 		}
 	}

--- a/overlay/emu_overlay_cfg.h
+++ b/overlay/emu_overlay_cfg.h
@@ -39,6 +39,7 @@ typedef struct {
 	int current_value;
 	int staged_value;
 	bool dirty;
+	bool restart_required; // taking effect requires relaunching the emulator
 } EmuOvlItem;
 
 typedef struct {
@@ -79,5 +80,11 @@ void emu_ovl_cfg_reset_section_to_defaults(EmuOvlSection* sec);
 void emu_ovl_cfg_reset_all_to_defaults(EmuOvlConfig* cfg);
 void emu_ovl_cfg_apply_staged(EmuOvlConfig* cfg);
 bool emu_ovl_cfg_has_changes(EmuOvlConfig* cfg);
+
+// Returns true if any item is both dirty (staged != current) AND tagged
+// restart_required in the JSON. Used to decide whether to show the
+// "Apply restart-required settings?" prompt after a Save.
+// Must be called BEFORE emu_ovl_cfg_apply_staged() since apply clears dirty.
+bool emu_ovl_cfg_any_dirty_restart_required(EmuOvlConfig* cfg);
 
 #endif


### PR DESCRIPTION
## Summary

Some settings only take effect when the emulator is relaunched (CPU overclock, audio resampler, threaded video, FPS/Speed/VI overlays). Previously the only signal was a "(restart required)" hint in the description; users had to manually quit to the launcher and reopen the game for the change to apply.

This change adds an opt-in flow: after picking **Save for Console** or **Save for Game**, if any dirty setting is flagged restart-required, a follow-up **"Apply Restart-Required Settings?"** Yes/No prompt appears.

- **Yes** writes a temporary save state to ``/tmp/m64p_restart_state.m64p`` (outside the user's regular save slots), drops a marker file, and stops the core. ``launch.sh``'s new outer loop relaunches mupen64plus and the frontend auto-loads the temp state via ``EMU_RESUME_PATH`` — landing the user back in-game with the new settings active.
- **No** just saves the config; the change applies on the next manual launch.
- **B** cancels back to the Save Changes screen without saving.

The temp state is unconditionally removed on the final exit so the user's save slots are never touched.

The new ``"restart_required": true`` JSON field on individual items drives the prompt; settings without it (Frame Skip, CPU Mode, etc.) save silently as before.