### PR TITLE
feat: support TrimUI Brick Pro

### DIFF
--- a/config/shared/launch.sh
+++ b/config/shared/launch.sh
@@ -81,6 +81,10 @@ case "$PLATFORM" in
             DEVICE_CONFIG_DIR="$USERDATA_DIR/brick"
             DEVICE_RESOLUTION="1024x768"
             LEGACY_CONFIG_DIR="$LEGACY_USERDATA_DIR/config/tg5040-brick"
+        elif [ "$DEVICE" = "brickpro" ]; then
+            DEVICE_CONFIG_DIR="$USERDATA_DIR/brick-pro"
+            DEVICE_RESOLUTION="1024x768"
+            LEGACY_CONFIG_DIR="$LEGACY_USERDATA_DIR/config/tg5040-brick-pro"
         else
             DEVICE_CONFIG_DIR="$USERDATA_DIR/smart-pro"
             DEVICE_RESOLUTION="1280x720"


### PR DESCRIPTION
The Brick Pro is just a variation of tg5040, with the same resolution as the brick, so updating lauch.sh is sufficient.

I don't have the device myself, but this has been tested to work on by users on NextUI Discord.